### PR TITLE
Muon example fix

### DIFF
--- a/examples/04.MuonScan/CosmicMuons.rml
+++ b/examples/04.MuonScan/CosmicMuons.rml
@@ -1,44 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
-<!--         
-First concept author G. Luzón (16-11-2020) -->
+			<!--         
+			First concept author G. Luzón (16-11-2020) -->
 
 <restG4>
 
-    <TRestRun name="CosmicMuonRun" title="A basic muon test with 2 active volumes">
-        <parameter name="experimentName" value="CosmicMuonScan"/>
-        <parameter name="readOnly" value="false" />
-        <parameter name="runNumber" value="111"/>
-        <parameter name="runDescription" value=""/>
-        <parameter name="user" value="${USER}"/>
-        <parameter name="verboseLevel" value="1"/>
-        <parameter name="overwrite" value="off" />
-        <parameter name="outputFileName" value="Run[fRunNumber]_[fRunType]_[fRunTag]_[fRunUser].root" />
-    </TRestRun>
+	<TRestRun name="CosmicMuonRun" title="A basic muon test with 2 active volumes">
+		<parameter name="experimentName" value="CosmicMuonScan"/>
+		<parameter name="readOnly" value="false" />
+		<parameter name="runNumber" value="111"/>
+		<parameter name="runDescription" value=""/>
+		<parameter name="user" value="${USER}"/>
+		<parameter name="verboseLevel" value="1"/>
+		<parameter name="overwrite" value="off" />
+		<parameter name="outputFileName" value="Run[fRunNumber]_[fRunType]_[fRunTag]_[fRunUser].root" />
+	</TRestRun>
 
-    <TRestGeant4Metadata name="restG4 run"  title="MuonsFromWall">
+	<TRestGeant4Metadata name="restG4 run"  title="MuonsFromWall">
 
-        <parameter name="gdml_file" value="setup.gdml"/>
-        <parameter name="subEventTimeDelay" value="100us" />
+		<parameter name="gdml_file" value="setup.gdml"/>
+		<parameter name="subEventTimeDelay" value="100us" />
 
-        <parameter name="Nevents" value="1000" />
+		<parameter name="Nevents" value="1000" />
 
-         <parameter name="saveAllEvents" value="false" />
-        <parameter name="printProgress" value="true" />
+		<parameter name="saveAllEvents" value="false" />
+		<parameter name="printProgress" value="true" />
 
-       <generator type="surface" shape="wall" position="(0,0,-50)cm" size="(30,30,0)cm" rotation="(90,0,0)" >
-            <source particle="mu-" excitedLevel="0.0" fullChain="on">
-                <energyDist type="TH1D" file="Muons.root" spctName="cosmicmuon" /> 
-                <angularDist type="TH1D" file="CosmicAngles.root" spctName="Theta2" />
-            </source> 
-        </generator>
+		<!-- We do not need to rotate our wall, because it is at XY plane already. But if needed, we might use a rotation axis,
+		and a rotationDeg to rotate the wall respect to that rotation axis -->
+		<generator type="surface" shape="wall" position="(0,0,-50)cm" size="(30,30,0)cm" rotationAxis="(0,0,1)" rotationDeg="0">
+			<source particle="mu-" excitedLevel="0.0" fullChain="on">
+				<energyDist type="TH1D" file="Muons.root" spctName="cosmicmuon" /> 
+				<angularDist type="TH1D" file="CosmicAngles.root" spctName="Theta2" />
+			</source> 
+		</generator>
 
-        <storage sensitiveVolume="det_dw_01" >
-            <parameter name="energyRange" value="(0,10)"units="GeV" />
+		<storage sensitiveVolume="det_dw_01" >
+			<parameter name="energyRange" value="(0,10)"units="GeV" />
 			<activeVolume name="det_dw_01" chance="1" maxStepSize="1mm" />
 			<activeVolume name="det_up_01" chance="1" maxStepSize="1mm" />
-        </storage>
-    </TRestGeant4Metadata>
+		</storage>
+	</TRestGeant4Metadata>
 
 	<TRestGeant4PhysicsLists name="default" title="First physics list implementation." verboseLevel="warning" >
 		<parameter name="cutForGamma" value="1" units="um" />
@@ -52,8 +54,6 @@ First concept author G. Luzón (16-11-2020) -->
 
 		<!-- EM Physics lists -->
 		<physicsList name="G4EmLivermorePhysics"> </physicsList>
-		<!-- <physicsList name="G4EmPenelopePhysics"> </physicsList> -->
-		<!-- <physicsList name="G4EmStandardPhysics_option3"> </physicsList> -->
 
 		<!-- Decay physics lists -->
 		<physicsList name="G4DecayPhysics"> </physicsList>
@@ -64,12 +64,10 @@ First concept author G. Luzón (16-11-2020) -->
 		</physicsList>
 
 		<!-- Hadron physics lists -->
-
 		<physicsList name="G4HadronElasticPhysicsHP"> </physicsList>
 		<physicsList name="G4IonBinaryCascadePhysics"> </physicsList>
 		<physicsList name="G4HadronPhysicsQGSP_BIC_HP"> </physicsList>
 		<physicsList name="G4EmExtraPhysics"> </physicsList>
 
 	</TRestGeant4PhysicsLists>
-
 </restG4>

--- a/examples/04.MuonScan/ValidateWall.C
+++ b/examples/04.MuonScan/ValidateWall.C
@@ -29,8 +29,8 @@ Int_t ValidateWall(string fname) {
     }
 
     cout << "Run entries: " << run->GetEntries() << endl;
-    if (run->GetEntries() != 904) {
-        cout << "The number of entries is not 904!" << endl;
+    if (run->GetEntries() != 850) {
+        cout << "The number of entries less than 850!" << endl;
         cout << "Number of entries : " << run->GetEntries() << endl;
         return 6;
     }

--- a/examples/04.MuonScan/ValidateWall.C
+++ b/examples/04.MuonScan/ValidateWall.C
@@ -28,6 +28,13 @@ Int_t ValidateWall(string fname) {
         return 5;
     }
 
+    cout << "Run entries: " << run->GetEntries() << endl;
+    if (run->GetEntries() != 904) {
+        cout << "The number of entries is not 904!" << endl;
+        cout << "Number of entries : " << run->GetEntries() << endl;
+        return 6;
+    }
+
     cout << "All tests passed! [\033[32mOK\033[0m]\n";
     // Other tests like opening other metadata classes. Detector TGeoManager, etc.
 

--- a/examples/04.MuonScan/ValidateWall.C
+++ b/examples/04.MuonScan/ValidateWall.C
@@ -29,7 +29,7 @@ Int_t ValidateWall(string fname) {
     }
 
     cout << "Run entries: " << run->GetEntries() << endl;
-    if (run->GetEntries() != 850) {
+    if (run->GetEntries() < 850) {
         cout << "The number of entries less than 850!" << endl;
         cout << "Number of entries : " << run->GetEntries() << endl;
         return 6;


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![43](https://badgen.net/badge/Size/43/orange) [![](https://gitlab.cern.ch/rest-for-physics/restg4/badges/muon_example_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restg4/-/commits/muon_example_fix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- It redefines the RML CosmicMuons.rml to use the most recent nomenclature for generator rotation axis and angle.

- It includes a new validation condition to identify future problems on the wall generator.