### PR TITLE
Display N events stored

### DIFF
--- a/src/EventAction.cxx
+++ b/src/EventAction.cxx
@@ -27,11 +27,11 @@ void EventAction::BeginOfEventAction(const G4Event* geant4_event) {
 
     if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
         cout << "DEBUG: Start of event ID " << event_number << " (" << event_number + 1 << " of "
-             << restG4Metadata->GetNumberOfEvents() << ")" << endl;
+             << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored." << endl;
     } else if ((restG4Metadata->PrintProgress() || restG4Metadata->GetVerboseLevel() >= REST_Info) &&
                geant4_event->GetEventID() % 10000 == 0) {
         cout << "INFO: Start of event ID " << event_number << " (" << event_number + 1 << " of "
-             << restG4Metadata->GetNumberOfEvents() << ")" << endl
+             << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored." << endl
              << endl;
     }
 

--- a/src/RunAction.cxx
+++ b/src/RunAction.cxx
@@ -1,5 +1,6 @@
 
 #include "RunAction.h"
+#include "TRestRun.h"
 
 #include <PrimaryGeneratorAction.h>
 #include <TRestGeant4Metadata.h>
@@ -12,6 +13,7 @@
 #include <iomanip>
 
 extern TRestGeant4Metadata* restG4Metadata;
+extern TRestRun* restRun;
 
 RunAction::RunAction(PrimaryGeneratorAction* gen) : G4UserRunAction(), fPrimary(gen) {}
 
@@ -33,7 +35,7 @@ void RunAction::EndOfRunAction(const G4Run* run) {
     // G4double eprimary = fPrimary->GetParticleGun()->GetParticleEnergy();
 
     G4cout << "======================== run summary ======================";
-    G4cout << "\n" << nbEvents << " Events simulated\n";
+    G4cout << "\n" << nbEvents << " Events simulated, " << restRun->GetEntries() << "Events stored\n";
     G4cout << "===========================================================";
     G4cout << G4endl;
 


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![5](https://badgen.net/badge/Size/5/orange) [![](https://gitlab.cern.ch/rest-for-physics/restg4/badges/nkx111-patch-1/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restg4/-/commits/nkx111-patch-1)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added a message showing how many events are stored during/after execution, as a hint for whether the rml is right or not.