### PR TITLE
Integrated changes from TRestGeant4Geometry, added new example with a…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif ()
 # Set include and lib
 set(INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include ${ROOT_INCLUDE_DIRS} ${rest_include_dirs} ${Geant4_INCLUDE_DIR})
 
-set(LINK_LIBRARIES ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} -lGui -lGeom -lGdml -lMinuit RestGeant4)
+set(LINK_LIBRARIES ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} -lGui -lGeom -lGdml -lMinuit -lXMLIO RestGeant4)
 string(STRIP "${LINK_LIBRARIES}" LINK_LIBRARIES)
 
 file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cxx)

--- a/examples/08.BabyIAXO/CosmicNeutrons.rml
+++ b/examples/08.BabyIAXO/CosmicNeutrons.rml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<restG4>
+    <globals>
+        <parameter name="mainDataPath" value=""/>
+        <parameter name="verboseLevel" value="info"/>
+    </globals>
+
+    <TRestRun name="" title="">
+        <parameter name="experimentName" value="BabyIAXO"/>
+        <parameter name="runType" value="background"/>
+        <parameter name="runNumber" value="1"/>
+        <parameter name="runTag" value="CosmicNeutrons"/>
+        <parameter name="outputFileName" value="Run[fRunNumber]_[fRunTag]_[fExperimentName].root"/>
+        <parameter name="runDescription" value=""/>
+        <parameter name="user" value="${USER}"/>
+        <parameter name="overwrite" value="off"/>
+        <parameter name="readOnly" value="false"/>
+    </TRestRun>
+
+    <TRestGeant4Metadata name="CosmicNeutrons" title="">
+
+        <parameter name="gdml_file" value="geometry/BabyIAXO-NoVetos.gdml"/>
+        <parameter name="subEventTimeDelay" value="100" units="us"/>
+
+        <parameter name="seed" value="111"/>
+
+        <!-- The number of events to be simulated is now defined in TRestGeant4Metadata -->
+        <parameter name="Nevents" value="3000"/>
+        <parameter name="saveAllEvents" value="false"/>
+
+        <generator type="surface" shape="wall" position="(0,0.5,0)m" size="(2.5,2.5,0)m" rotationAxis="(1,0,0)"
+                   rotationDeg="1.5708">
+
+            <source particle="neutron">
+                <energyDist type="TH1D" file="CosmicNeutrons.root" spctName="CosmicNeutrons"/>
+                <angularDist type="TH1D" file="CosmicAngles.root" spctName="Theta2" direction="(0,0,-1)"/>
+            </source>
+        </generator>
+
+        <storage sensitiveVolume="av_1_impr_1_gasVolume_pv_0">
+            <parameter name="energyRange" value="(0,1)" units="GeV"/>
+        </storage>
+
+    </TRestGeant4Metadata>
+
+    <TRestGeant4PhysicsLists name="default" title="First physics list implementation.">
+
+        <parameter name="cutForGamma" value="0.01" units="mm"/>
+        <parameter name="cutForElectron" value="2" units="mm"/>
+        <parameter name="cutForPositron" value="1" units="mm"/>
+
+        <parameter name="cutForMuon" value="1" units="mm"/>
+        <parameter name="cutForNeutron" value="1" units="mm"/>
+        <parameter name="minEnergyRangeProductionCuts" value="1" units="keV"/>
+        <parameter name="maxEnergyRangeProductionCuts" value="1" units="GeV"/>
+
+        // Use only one EM physics list
+        <!-- EM Physics lists -->
+        <!--<physicsList name="G4EmLivermorePhysics"> </physicsList>-->
+        <!-- <physicsList name="G4EmPenelopePhysics"> </physicsList> -->
+        <physicsList name="G4EmStandardPhysics_option4"/>
+
+        <!-- Decay physics lists -->
+        <physicsList name="G4DecayPhysics"/>
+        <physicsList name="G4RadioactiveDecayPhysics"/>
+        <physicsList name="G4RadioactiveDecay">
+            <option name="ICM" value="true"/>
+            <option name="ARM" value="true"/>
+        </physicsList>
+
+        <!-- Hadron physics lists -->
+        <physicsList name="G4HadronElasticPhysicsHP"/>
+        <physicsList name="G4IonBinaryCascadePhysics"/>
+        <physicsList name="G4HadronPhysicsQGSP_BIC_HP"/>
+        <!-- <physicsList name="G4NeutronTrackingCut"/> -->
+        <physicsList name="G4EmExtraPhysics"/>
+
+    </TRestGeant4PhysicsLists>
+
+</restG4>

--- a/examples/08.BabyIAXO/CosmicNeutrons.rml
+++ b/examples/08.BabyIAXO/CosmicNeutrons.rml
@@ -28,19 +28,23 @@
         <!-- The number of events to be simulated is now defined in TRestGeant4Metadata -->
         <parameter name="Nevents" value="3000"/>
         <parameter name="saveAllEvents" value="false"/>
-
+        <!--
         <generator type="surface" shape="wall" position="(0,0.5,0)m" size="(2.5,2.5,0)m" rotationAxis="(1,0,0)"
                    rotationDeg="1.5708">
-
+        -->
+        <generator type="point" position="(0,500,0)m">
             <source particle="neutron">
                 <energyDist type="TH1D" file="CosmicNeutrons.root" spctName="CosmicNeutrons"/>
-                <angularDist type="TH1D" file="CosmicAngles.root" spctName="Theta2" direction="(0,0,-1)"/>
+                <angularDist type="flux" direction="(0,-1,0)"/>
             </source>
         </generator>
 
-        <storage sensitiveVolume="av_1_impr_1_gasVolume_pv_0">
-            <parameter name="energyRange" value="(0,1)" units="GeV"/>
-        </storage>
+        <TRestGeant4Geometry>
+            <parameter name="allVolumesActive" value="true"/>
+            <parameter name="energyRange" value="(0,10)" units="GeV"/>
+            <volume name="gasVolume" chance="1" maxStepSize="1mm" sensitive="true"/>
+            <volume name="badVolume" chance="1" maxStepSize="1mm"/>
+        </TRestGeant4Geometry>
 
     </TRestGeant4Metadata>
 

--- a/examples/08.BabyIAXO/geometry/BabyIAXO-NoVetos.gdml
+++ b/examples/08.BabyIAXO/geometry/BabyIAXO-NoVetos.gdml
@@ -1,0 +1,3487 @@
+<?xml version='1.0'?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+    <define/>
+    <materials>
+        <isotope Z="1.0" N="1" name="H1">
+            <atom value="1.007825" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="1.0" N="2" name="H2">
+            <atom value="2.014102" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="H">
+            <fraction n="0.999885" ref="H1"/>
+            <fraction n="1.15E-4" ref="H2"/>
+        </element>
+        <isotope Z="2.0" N="3" name="He3">
+            <atom value="3.01693" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="2.0" N="4" name="He4">
+            <atom value="4.002644" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="He">
+            <fraction n="1.369999493E-6" ref="He3"/>
+            <fraction n="0.99999863" ref="He4"/>
+        </element>
+        <isotope Z="3.0" N="6" name="Li6">
+            <atom value="6.01512" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="3.0" N="7" name="Li7">
+            <atom value="7.016" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Li">
+            <fraction n="0.0759" ref="Li6"/>
+            <fraction n="0.9241" ref="Li7"/>
+        </element>
+        <isotope Z="4.0" N="9" name="Be9">
+            <atom value="9.01218" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Be">
+            <fraction n="1.0" ref="Be9"/>
+        </element>
+        <isotope Z="5.0" N="10" name="B10">
+            <atom value="10.0129" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="5.0" N="11" name="B11">
+            <atom value="11.0093" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="B">
+            <fraction n="0.199" ref="B10"/>
+            <fraction n="0.801" ref="B11"/>
+        </element>
+        <isotope Z="6.0" N="12" name="C12">
+            <atom value="12.0" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="6.0" N="13" name="C13">
+            <atom value="13.0034" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="C">
+            <fraction n="0.9893" ref="C12"/>
+            <fraction n="0.0107" ref="C13"/>
+        </element>
+        <isotope Z="7.0" N="14" name="N14">
+            <atom value="14.0031" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="7.0" N="15" name="N15">
+            <atom value="15.0001" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="N">
+            <fraction n="0.99632" ref="N14"/>
+            <fraction n="0.00368" ref="N15"/>
+        </element>
+        <isotope Z="8.0" N="16" name="O16">
+            <atom value="15.9949" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="8.0" N="17" name="O17">
+            <atom value="16.9991" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="8.0" N="18" name="O18">
+            <atom value="17.9992" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="O">
+            <fraction n="0.99757" ref="O16"/>
+            <fraction n="3.8E-4" ref="O17"/>
+            <fraction n="0.00205" ref="O18"/>
+        </element>
+        <isotope Z="9.0" N="19" name="F19">
+            <atom value="18.9984" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="F">
+            <fraction n="1.0" ref="F19"/>
+        </element>
+        <isotope Z="10.0" N="20" name="Ne20">
+            <atom value="19.9924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="10.0" N="21" name="Ne21">
+            <atom value="20.9938" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="10.0" N="22" name="Ne22">
+            <atom value="21.9914" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ne">
+            <fraction n="0.9048" ref="Ne20"/>
+            <fraction n="0.0027" ref="Ne21"/>
+            <fraction n="0.0925" ref="Ne22"/>
+        </element>
+        <isotope Z="11.0" N="23" name="Na23">
+            <atom value="22.9898" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Na">
+            <fraction n="1.0" ref="Na23"/>
+        </element>
+        <isotope Z="12.0" N="24" name="Mg24">
+            <atom value="23.985" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="12.0" N="25" name="Mg25">
+            <atom value="24.9858" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="12.0" N="26" name="Mg26">
+            <atom value="25.9826" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Mg">
+            <fraction n="0.7899" ref="Mg24"/>
+            <fraction n="0.1" ref="Mg25"/>
+            <fraction n="0.1101" ref="Mg26"/>
+        </element>
+        <isotope Z="13.0" N="27" name="Al27">
+            <atom value="26.9815" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Al">
+            <fraction n="1.0" ref="Al27"/>
+        </element>
+        <isotope Z="14.0" N="28" name="Si28">
+            <atom value="27.9769" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="14.0" N="29" name="Si29">
+            <atom value="28.9765" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="14.0" N="30" name="Si30">
+            <atom value="29.9738" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Si">
+            <fraction n="0.9222960777" ref="Si28"/>
+            <fraction n="0.04683195317" ref="Si29"/>
+            <fraction n="0.03087196913" ref="Si30"/>
+        </element>
+        <isotope Z="15.0" N="31" name="P31">
+            <atom value="30.9738" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="P">
+            <fraction n="1.0" ref="P31"/>
+        </element>
+        <isotope Z="16.0" N="32" name="S32">
+            <atom value="31.9721" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="16.0" N="33" name="S33">
+            <atom value="32.9715" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="16.0" N="34" name="S34">
+            <atom value="33.9679" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="16.0" N="36" name="S36">
+            <atom value="35.9671" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="S">
+            <fraction n="0.9493" ref="S32"/>
+            <fraction n="0.0076" ref="S33"/>
+            <fraction n="0.0429" ref="S34"/>
+            <fraction n="2.0E-4" ref="S36"/>
+        </element>
+        <isotope Z="17.0" N="35" name="Cl35">
+            <atom value="34.9689" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="17.0" N="37" name="Cl37">
+            <atom value="36.9659" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cl">
+            <fraction n="0.7578" ref="Cl35"/>
+            <fraction n="0.2422" ref="Cl37"/>
+        </element>
+        <isotope Z="18.0" N="36" name="Ar36">
+            <atom value="35.9675" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="18.0" N="38" name="Ar38">
+            <atom value="37.9627" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="18.0" N="40" name="Ar40">
+            <atom value="39.9624" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ar">
+            <fraction n="0.003365" ref="Ar36"/>
+            <fraction n="6.32E-4" ref="Ar38"/>
+            <fraction n="0.996003" ref="Ar40"/>
+        </element>
+        <isotope Z="19.0" N="39" name="K39">
+            <atom value="38.9637" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="19.0" N="40" name="K40">
+            <atom value="39.964" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="19.0" N="41" name="K41">
+            <atom value="40.9618" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="K">
+            <fraction n="0.932581" ref="K39"/>
+            <fraction n="1.17E-4" ref="K40"/>
+            <fraction n="0.067302" ref="K41"/>
+        </element>
+        <isotope Z="20.0" N="40" name="Ca40">
+            <atom value="39.9626" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="42" name="Ca42">
+            <atom value="41.9586" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="43" name="Ca43">
+            <atom value="42.9588" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="44" name="Ca44">
+            <atom value="43.9555" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="46" name="Ca46">
+            <atom value="45.9537" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="20.0" N="48" name="Ca48">
+            <atom value="47.9525" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ca">
+            <fraction n="0.96941" ref="Ca40"/>
+            <fraction n="0.00647" ref="Ca42"/>
+            <fraction n="0.00135" ref="Ca43"/>
+            <fraction n="0.02086" ref="Ca44"/>
+            <fraction n="4.0E-5" ref="Ca46"/>
+            <fraction n="0.00187" ref="Ca48"/>
+        </element>
+        <isotope Z="21.0" N="45" name="Sc45">
+            <atom value="44.9559" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sc">
+            <fraction n="1.0" ref="Sc45"/>
+        </element>
+        <isotope Z="22.0" N="46" name="Ti46">
+            <atom value="45.9526" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="47" name="Ti47">
+            <atom value="46.9518" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="48" name="Ti48">
+            <atom value="47.9479" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="49" name="Ti49">
+            <atom value="48.9479" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="22.0" N="50" name="Ti50">
+            <atom value="49.9448" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ti">
+            <fraction n="0.0825" ref="Ti46"/>
+            <fraction n="0.0744" ref="Ti47"/>
+            <fraction n="0.7372" ref="Ti48"/>
+            <fraction n="0.0541" ref="Ti49"/>
+            <fraction n="0.0518" ref="Ti50"/>
+        </element>
+        <isotope Z="23.0" N="50" name="V50">
+            <atom value="49.9472" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="23.0" N="51" name="V51">
+            <atom value="50.944" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="V">
+            <fraction n="0.0025" ref="V50"/>
+            <fraction n="0.9975" ref="V51"/>
+        </element>
+        <isotope Z="24.0" N="50" name="Cr50">
+            <atom value="49.946" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="24.0" N="52" name="Cr52">
+            <atom value="51.9405" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="24.0" N="53" name="Cr53">
+            <atom value="52.9407" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="24.0" N="54" name="Cr54">
+            <atom value="53.9389" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cr">
+            <fraction n="0.04345" ref="Cr50"/>
+            <fraction n="0.83789" ref="Cr52"/>
+            <fraction n="0.09501" ref="Cr53"/>
+            <fraction n="0.02365" ref="Cr54"/>
+        </element>
+        <isotope Z="25.0" N="55" name="Mn55">
+            <atom value="54.938" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Mn">
+            <fraction n="1.0" ref="Mn55"/>
+        </element>
+        <isotope Z="26.0" N="54" name="Fe54">
+            <atom value="53.9396" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="26.0" N="56" name="Fe56">
+            <atom value="55.9349" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="26.0" N="57" name="Fe57">
+            <atom value="56.9354" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="26.0" N="58" name="Fe58">
+            <atom value="57.9333" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Fe">
+            <fraction n="0.05845" ref="Fe54"/>
+            <fraction n="0.91754" ref="Fe56"/>
+            <fraction n="0.02119" ref="Fe57"/>
+            <fraction n="0.00282" ref="Fe58"/>
+        </element>
+        <isotope Z="27.0" N="59" name="Co59">
+            <atom value="58.9332" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Co">
+            <fraction n="1.0" ref="Co59"/>
+        </element>
+        <isotope Z="28.0" N="58" name="Ni58">
+            <atom value="57.9353" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="60" name="Ni60">
+            <atom value="59.9308" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="61" name="Ni61">
+            <atom value="60.9311" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="62" name="Ni62">
+            <atom value="61.9283" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="28.0" N="64" name="Ni64">
+            <atom value="63.928" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ni">
+            <fraction n="0.680769" ref="Ni58"/>
+            <fraction n="0.262231" ref="Ni60"/>
+            <fraction n="0.011399" ref="Ni61"/>
+            <fraction n="0.036345" ref="Ni62"/>
+            <fraction n="0.009256" ref="Ni64"/>
+        </element>
+        <isotope Z="29.0" N="63" name="Cu63">
+            <atom value="62.9296" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="29.0" N="65" name="Cu65">
+            <atom value="64.9278" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cu">
+            <fraction n="0.6917" ref="Cu63"/>
+            <fraction n="0.3083" ref="Cu65"/>
+        </element>
+        <isotope Z="30.0" N="64" name="Zn64">
+            <atom value="63.9291" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="66" name="Zn66">
+            <atom value="65.926" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="67" name="Zn67">
+            <atom value="66.9271" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="68" name="Zn68">
+            <atom value="67.9248" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="30.0" N="70" name="Zn70">
+            <atom value="69.9253" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Zn">
+            <fraction n="0.4863" ref="Zn64"/>
+            <fraction n="0.279" ref="Zn66"/>
+            <fraction n="0.041" ref="Zn67"/>
+            <fraction n="0.1875" ref="Zn68"/>
+            <fraction n="0.0062" ref="Zn70"/>
+        </element>
+        <isotope Z="31.0" N="69" name="Ga69">
+            <atom value="68.9256" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="31.0" N="71" name="Ga71">
+            <atom value="70.9247" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ga">
+            <fraction n="0.60108" ref="Ga69"/>
+            <fraction n="0.39892" ref="Ga71"/>
+        </element>
+        <isotope Z="32.0" N="70" name="Ge70">
+            <atom value="69.9243" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="72" name="Ge72">
+            <atom value="71.9221" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="73" name="Ge73">
+            <atom value="72.9235" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="74" name="Ge74">
+            <atom value="73.9212" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="32.0" N="76" name="Ge76">
+            <atom value="75.9214" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ge">
+            <fraction n="0.2084" ref="Ge70"/>
+            <fraction n="0.2754" ref="Ge72"/>
+            <fraction n="0.0773" ref="Ge73"/>
+            <fraction n="0.3628" ref="Ge74"/>
+            <fraction n="0.0761" ref="Ge76"/>
+        </element>
+        <isotope Z="33.0" N="75" name="As75">
+            <atom value="74.9216" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="As">
+            <fraction n="1.0" ref="As75"/>
+        </element>
+        <isotope Z="34.0" N="74" name="Se74">
+            <atom value="73.9225" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="76" name="Se76">
+            <atom value="75.9192" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="77" name="Se77">
+            <atom value="76.9199" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="78" name="Se78">
+            <atom value="77.9173" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="80" name="Se80">
+            <atom value="79.9165" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="34.0" N="82" name="Se82">
+            <atom value="81.9167" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Se">
+            <fraction n="0.0089" ref="Se74"/>
+            <fraction n="0.0937" ref="Se76"/>
+            <fraction n="0.0763" ref="Se77"/>
+            <fraction n="0.2377" ref="Se78"/>
+            <fraction n="0.4961" ref="Se80"/>
+            <fraction n="0.0873" ref="Se82"/>
+        </element>
+        <isotope Z="35.0" N="79" name="Br79">
+            <atom value="78.9183" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="35.0" N="81" name="Br81">
+            <atom value="80.9163" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Br">
+            <fraction n="0.5069" ref="Br79"/>
+            <fraction n="0.4931" ref="Br81"/>
+        </element>
+        <isotope Z="36.0" N="78" name="Kr78">
+            <atom value="77.9204" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="80" name="Kr80">
+            <atom value="79.9164" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="82" name="Kr82">
+            <atom value="81.9135" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="83" name="Kr83">
+            <atom value="82.9141" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="84" name="Kr84">
+            <atom value="83.9115" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="36.0" N="86" name="Kr86">
+            <atom value="85.9106" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Kr">
+            <fraction n="0.0035" ref="Kr78"/>
+            <fraction n="0.0228" ref="Kr80"/>
+            <fraction n="0.1158" ref="Kr82"/>
+            <fraction n="0.1149" ref="Kr83"/>
+            <fraction n="0.57" ref="Kr84"/>
+            <fraction n="0.173" ref="Kr86"/>
+        </element>
+        <isotope Z="37.0" N="85" name="Rb85">
+            <atom value="84.9118" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="37.0" N="87" name="Rb87">
+            <atom value="86.9092" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Rb">
+            <fraction n="0.7217" ref="Rb85"/>
+            <fraction n="0.2783" ref="Rb87"/>
+        </element>
+        <isotope Z="38.0" N="84" name="Sr84">
+            <atom value="83.9134" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="38.0" N="86" name="Sr86">
+            <atom value="85.9093" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="38.0" N="87" name="Sr87">
+            <atom value="86.9089" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="38.0" N="88" name="Sr88">
+            <atom value="87.9056" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sr">
+            <fraction n="0.0056" ref="Sr84"/>
+            <fraction n="0.0986" ref="Sr86"/>
+            <fraction n="0.07" ref="Sr87"/>
+            <fraction n="0.8258" ref="Sr88"/>
+        </element>
+        <isotope Z="39.0" N="89" name="Y89">
+            <atom value="88.9058" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Y">
+            <fraction n="1.0" ref="Y89"/>
+        </element>
+        <isotope Z="40.0" N="90" name="Zr90">
+            <atom value="89.9047" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="91" name="Zr91">
+            <atom value="90.9056" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="92" name="Zr92">
+            <atom value="91.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="94" name="Zr94">
+            <atom value="93.9063" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="40.0" N="96" name="Zr96">
+            <atom value="95.9083" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Zr">
+            <fraction n="0.5145" ref="Zr90"/>
+            <fraction n="0.1122" ref="Zr91"/>
+            <fraction n="0.1715" ref="Zr92"/>
+            <fraction n="0.1738" ref="Zr94"/>
+            <fraction n="0.028" ref="Zr96"/>
+        </element>
+        <isotope Z="41.0" N="93" name="Nb93">
+            <atom value="92.9064" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Nb">
+            <fraction n="1.0" ref="Nb93"/>
+        </element>
+        <isotope Z="42.0" N="92" name="Mo92">
+            <atom value="91.9068" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="94" name="Mo94">
+            <atom value="93.9051" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="95" name="Mo95">
+            <atom value="94.9058" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="96" name="Mo96">
+            <atom value="95.9047" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="97" name="Mo97">
+            <atom value="96.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="98" name="Mo98">
+            <atom value="97.9054" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="42.0" N="100" name="Mo100">
+            <atom value="99.9075" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Mo">
+            <fraction n="0.1484" ref="Mo92"/>
+            <fraction n="0.0925" ref="Mo94"/>
+            <fraction n="0.1592" ref="Mo95"/>
+            <fraction n="0.1668" ref="Mo96"/>
+            <fraction n="0.0955" ref="Mo97"/>
+            <fraction n="0.2413" ref="Mo98"/>
+            <fraction n="0.0963" ref="Mo100"/>
+        </element>
+        <isotope Z="43.0" N="98" name="Tc98">
+            <atom value="97.9072" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tc">
+            <fraction n="1.0" ref="Tc98"/>
+        </element>
+        <isotope Z="44.0" N="96" name="Ru96">
+            <atom value="95.9076" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="98" name="Ru98">
+            <atom value="97.9053" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="99" name="Ru99">
+            <atom value="98.9059" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="100" name="Ru100">
+            <atom value="99.9042" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="101" name="Ru101">
+            <atom value="100.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="102" name="Ru102">
+            <atom value="101.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="44.0" N="104" name="Ru104">
+            <atom value="103.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ru">
+            <fraction n="0.0554" ref="Ru96"/>
+            <fraction n="0.0187" ref="Ru98"/>
+            <fraction n="0.1276" ref="Ru99"/>
+            <fraction n="0.126" ref="Ru100"/>
+            <fraction n="0.1706" ref="Ru101"/>
+            <fraction n="0.3155" ref="Ru102"/>
+            <fraction n="0.1862" ref="Ru104"/>
+        </element>
+        <isotope Z="45.0" N="103" name="Rh103">
+            <atom value="102.906" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Rh">
+            <fraction n="1.0" ref="Rh103"/>
+        </element>
+        <isotope Z="46.0" N="102" name="Pd102">
+            <atom value="101.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="104" name="Pd104">
+            <atom value="103.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="105" name="Pd105">
+            <atom value="104.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="106" name="Pd106">
+            <atom value="105.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="108" name="Pd108">
+            <atom value="107.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="46.0" N="110" name="Pd110">
+            <atom value="109.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pd">
+            <fraction n="0.0102" ref="Pd102"/>
+            <fraction n="0.1114" ref="Pd104"/>
+            <fraction n="0.2233" ref="Pd105"/>
+            <fraction n="0.2733" ref="Pd106"/>
+            <fraction n="0.2646" ref="Pd108"/>
+            <fraction n="0.1172" ref="Pd110"/>
+        </element>
+        <isotope Z="47.0" N="107" name="Ag107">
+            <atom value="106.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="47.0" N="109" name="Ag109">
+            <atom value="108.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ag">
+            <fraction n="0.51839" ref="Ag107"/>
+            <fraction n="0.48161" ref="Ag109"/>
+        </element>
+        <isotope Z="48.0" N="106" name="Cd106">
+            <atom value="105.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="108" name="Cd108">
+            <atom value="107.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="110" name="Cd110">
+            <atom value="109.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="111" name="Cd111">
+            <atom value="110.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="112" name="Cd112">
+            <atom value="111.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="113" name="Cd113">
+            <atom value="112.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="114" name="Cd114">
+            <atom value="113.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="48.0" N="116" name="Cd116">
+            <atom value="115.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cd">
+            <fraction n="0.0125" ref="Cd106"/>
+            <fraction n="0.0089" ref="Cd108"/>
+            <fraction n="0.1249" ref="Cd110"/>
+            <fraction n="0.128" ref="Cd111"/>
+            <fraction n="0.2413" ref="Cd112"/>
+            <fraction n="0.1222" ref="Cd113"/>
+            <fraction n="0.2873" ref="Cd114"/>
+            <fraction n="0.0749" ref="Cd116"/>
+        </element>
+        <isotope Z="49.0" N="113" name="In113">
+            <atom value="112.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="49.0" N="115" name="In115">
+            <atom value="114.904" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="In">
+            <fraction n="0.0429" ref="In113"/>
+            <fraction n="0.9571" ref="In115"/>
+        </element>
+        <isotope Z="50.0" N="112" name="Sn112">
+            <atom value="111.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="114" name="Sn114">
+            <atom value="113.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="115" name="Sn115">
+            <atom value="114.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="116" name="Sn116">
+            <atom value="115.902" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="117" name="Sn117">
+            <atom value="116.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="118" name="Sn118">
+            <atom value="117.902" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="119" name="Sn119">
+            <atom value="118.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="120" name="Sn120">
+            <atom value="119.902" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="122" name="Sn122">
+            <atom value="121.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="50.0" N="124" name="Sn124">
+            <atom value="123.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sn">
+            <fraction n="0.0097" ref="Sn112"/>
+            <fraction n="0.0066" ref="Sn114"/>
+            <fraction n="0.0034" ref="Sn115"/>
+            <fraction n="0.1454" ref="Sn116"/>
+            <fraction n="0.0768" ref="Sn117"/>
+            <fraction n="0.2422" ref="Sn118"/>
+            <fraction n="0.0859" ref="Sn119"/>
+            <fraction n="0.3258" ref="Sn120"/>
+            <fraction n="0.0463" ref="Sn122"/>
+            <fraction n="0.0579" ref="Sn124"/>
+        </element>
+        <isotope Z="51.0" N="121" name="Sb121">
+            <atom value="120.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="51.0" N="123" name="Sb123">
+            <atom value="122.904" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sb">
+            <fraction n="0.5721" ref="Sb121"/>
+            <fraction n="0.4279" ref="Sb123"/>
+        </element>
+        <isotope Z="52.0" N="120" name="Te120">
+            <atom value="119.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="122" name="Te122">
+            <atom value="121.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="123" name="Te123">
+            <atom value="122.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="124" name="Te124">
+            <atom value="123.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="125" name="Te125">
+            <atom value="124.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="126" name="Te126">
+            <atom value="125.903" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="128" name="Te128">
+            <atom value="127.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="52.0" N="130" name="Te130">
+            <atom value="129.906" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Te">
+            <fraction n="9.0E-4" ref="Te120"/>
+            <fraction n="0.0255" ref="Te122"/>
+            <fraction n="0.0089" ref="Te123"/>
+            <fraction n="0.0474" ref="Te124"/>
+            <fraction n="0.0707" ref="Te125"/>
+            <fraction n="0.1884" ref="Te126"/>
+            <fraction n="0.3174" ref="Te128"/>
+            <fraction n="0.3408" ref="Te130"/>
+        </element>
+        <isotope Z="53.0" N="127" name="I127">
+            <atom value="126.904" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="I">
+            <fraction n="1.0" ref="I127"/>
+        </element>
+        <isotope Z="54.0" N="124" name="Xe124">
+            <atom value="123.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="126" name="Xe126">
+            <atom value="125.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="128" name="Xe128">
+            <atom value="127.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="129" name="Xe129">
+            <atom value="128.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="130" name="Xe130">
+            <atom value="129.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="131" name="Xe131">
+            <atom value="130.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="132" name="Xe132">
+            <atom value="131.904" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="134" name="Xe134">
+            <atom value="133.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="54.0" N="136" name="Xe136">
+            <atom value="135.907" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Xe">
+            <fraction n="9.0E-4" ref="Xe124"/>
+            <fraction n="9.0E-4" ref="Xe126"/>
+            <fraction n="0.0192" ref="Xe128"/>
+            <fraction n="0.2644" ref="Xe129"/>
+            <fraction n="0.0408" ref="Xe130"/>
+            <fraction n="0.2118" ref="Xe131"/>
+            <fraction n="0.2689" ref="Xe132"/>
+            <fraction n="0.1044" ref="Xe134"/>
+            <fraction n="0.0887" ref="Xe136"/>
+        </element>
+        <isotope Z="55.0" N="133" name="Cs133">
+            <atom value="132.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Cs">
+            <fraction n="1.0" ref="Cs133"/>
+        </element>
+        <isotope Z="56.0" N="130" name="Ba130">
+            <atom value="129.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="132" name="Ba132">
+            <atom value="131.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="134" name="Ba134">
+            <atom value="133.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="135" name="Ba135">
+            <atom value="134.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="136" name="Ba136">
+            <atom value="135.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="137" name="Ba137">
+            <atom value="136.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="56.0" N="138" name="Ba138">
+            <atom value="137.905" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ba">
+            <fraction n="0.00106" ref="Ba130"/>
+            <fraction n="0.00101" ref="Ba132"/>
+            <fraction n="0.02417" ref="Ba134"/>
+            <fraction n="0.06592" ref="Ba135"/>
+            <fraction n="0.07854" ref="Ba136"/>
+            <fraction n="0.11232" ref="Ba137"/>
+            <fraction n="0.71698" ref="Ba138"/>
+        </element>
+        <isotope Z="57.0" N="138" name="La138">
+            <atom value="137.907" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="57.0" N="139" name="La139">
+            <atom value="138.906" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="La">
+            <fraction n="9.0E-4" ref="La138"/>
+            <fraction n="0.9991" ref="La139"/>
+        </element>
+        <isotope Z="58.0" N="136" name="Ce136">
+            <atom value="135.907" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="58.0" N="138" name="Ce138">
+            <atom value="137.906" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="58.0" N="140" name="Ce140">
+            <atom value="139.905" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="58.0" N="142" name="Ce142">
+            <atom value="141.909" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ce">
+            <fraction n="0.00185" ref="Ce136"/>
+            <fraction n="0.00251" ref="Ce138"/>
+            <fraction n="0.8845" ref="Ce140"/>
+            <fraction n="0.11114" ref="Ce142"/>
+        </element>
+        <isotope Z="59.0" N="141" name="Pr141">
+            <atom value="140.908" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pr">
+            <fraction n="1.0" ref="Pr141"/>
+        </element>
+        <isotope Z="60.0" N="142" name="Nd142">
+            <atom value="141.908" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="143" name="Nd143">
+            <atom value="142.91" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="144" name="Nd144">
+            <atom value="143.91" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="145" name="Nd145">
+            <atom value="144.913" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="146" name="Nd146">
+            <atom value="145.913" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="148" name="Nd148">
+            <atom value="147.917" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="60.0" N="150" name="Nd150">
+            <atom value="149.921" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Nd">
+            <fraction n="0.272" ref="Nd142"/>
+            <fraction n="0.122" ref="Nd143"/>
+            <fraction n="0.238" ref="Nd144"/>
+            <fraction n="0.083" ref="Nd145"/>
+            <fraction n="0.172" ref="Nd146"/>
+            <fraction n="0.057" ref="Nd148"/>
+            <fraction n="0.056" ref="Nd150"/>
+        </element>
+        <isotope Z="61.0" N="145" name="Pm145">
+            <atom value="144.913" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pm">
+            <fraction n="1.0" ref="Pm145"/>
+        </element>
+        <isotope Z="62.0" N="144" name="Sm144">
+            <atom value="143.912" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="147" name="Sm147">
+            <atom value="146.915" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="148" name="Sm148">
+            <atom value="147.915" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="149" name="Sm149">
+            <atom value="148.917" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="150" name="Sm150">
+            <atom value="149.917" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="152" name="Sm152">
+            <atom value="151.92" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="62.0" N="154" name="Sm154">
+            <atom value="153.922" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Sm">
+            <fraction n="0.0307" ref="Sm144"/>
+            <fraction n="0.1499" ref="Sm147"/>
+            <fraction n="0.1124" ref="Sm148"/>
+            <fraction n="0.1382" ref="Sm149"/>
+            <fraction n="0.0738" ref="Sm150"/>
+            <fraction n="0.2675" ref="Sm152"/>
+            <fraction n="0.2275" ref="Sm154"/>
+        </element>
+        <isotope Z="63.0" N="151" name="Eu151">
+            <atom value="150.92" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="63.0" N="153" name="Eu153">
+            <atom value="152.921" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Eu">
+            <fraction n="0.4781" ref="Eu151"/>
+            <fraction n="0.5219" ref="Eu153"/>
+        </element>
+        <isotope Z="64.0" N="152" name="Gd152">
+            <atom value="151.92" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="154" name="Gd154">
+            <atom value="153.921" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="155" name="Gd155">
+            <atom value="154.923" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="156" name="Gd156">
+            <atom value="155.922" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="157" name="Gd157">
+            <atom value="156.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="158" name="Gd158">
+            <atom value="157.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="64.0" N="160" name="Gd160">
+            <atom value="159.927" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Gd">
+            <fraction n="0.002" ref="Gd152"/>
+            <fraction n="0.0218" ref="Gd154"/>
+            <fraction n="0.148" ref="Gd155"/>
+            <fraction n="0.2047" ref="Gd156"/>
+            <fraction n="0.1565" ref="Gd157"/>
+            <fraction n="0.2484" ref="Gd158"/>
+            <fraction n="0.2186" ref="Gd160"/>
+        </element>
+        <isotope Z="65.0" N="159" name="Tb159">
+            <atom value="158.925" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tb">
+            <fraction n="1.0" ref="Tb159"/>
+        </element>
+        <isotope Z="66.0" N="156" name="Dy156">
+            <atom value="155.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="158" name="Dy158">
+            <atom value="157.924" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="160" name="Dy160">
+            <atom value="159.925" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="161" name="Dy161">
+            <atom value="160.927" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="162" name="Dy162">
+            <atom value="161.927" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="163" name="Dy163">
+            <atom value="162.929" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="66.0" N="164" name="Dy164">
+            <atom value="163.929" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Dy">
+            <fraction n="6.0E-4" ref="Dy156"/>
+            <fraction n="0.001" ref="Dy158"/>
+            <fraction n="0.0234" ref="Dy160"/>
+            <fraction n="0.1891" ref="Dy161"/>
+            <fraction n="0.2551" ref="Dy162"/>
+            <fraction n="0.249" ref="Dy163"/>
+            <fraction n="0.2818" ref="Dy164"/>
+        </element>
+        <isotope Z="67.0" N="165" name="Ho165">
+            <atom value="164.93" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ho">
+            <fraction n="1.0" ref="Ho165"/>
+        </element>
+        <isotope Z="68.0" N="162" name="Er162">
+            <atom value="161.929" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="164" name="Er164">
+            <atom value="163.929" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="166" name="Er166">
+            <atom value="165.93" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="167" name="Er167">
+            <atom value="166.932" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="168" name="Er168">
+            <atom value="167.932" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="68.0" N="170" name="Er170">
+            <atom value="169.935" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Er">
+            <fraction n="0.0014" ref="Er162"/>
+            <fraction n="0.0161" ref="Er164"/>
+            <fraction n="0.3361" ref="Er166"/>
+            <fraction n="0.2293" ref="Er167"/>
+            <fraction n="0.2678" ref="Er168"/>
+            <fraction n="0.1493" ref="Er170"/>
+        </element>
+        <isotope Z="69.0" N="169" name="Tm169">
+            <atom value="168.934" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tm">
+            <fraction n="1.0" ref="Tm169"/>
+        </element>
+        <isotope Z="70.0" N="168" name="Yb168">
+            <atom value="167.934" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="170" name="Yb170">
+            <atom value="169.935" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="171" name="Yb171">
+            <atom value="170.936" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="172" name="Yb172">
+            <atom value="171.936" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="173" name="Yb173">
+            <atom value="172.938" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="174" name="Yb174">
+            <atom value="173.939" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="70.0" N="176" name="Yb176">
+            <atom value="175.943" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Yb">
+            <fraction n="0.0013" ref="Yb168"/>
+            <fraction n="0.0304" ref="Yb170"/>
+            <fraction n="0.1428" ref="Yb171"/>
+            <fraction n="0.2183" ref="Yb172"/>
+            <fraction n="0.1613" ref="Yb173"/>
+            <fraction n="0.3183" ref="Yb174"/>
+            <fraction n="0.1276" ref="Yb176"/>
+        </element>
+        <isotope Z="71.0" N="175" name="Lu175">
+            <atom value="174.941" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="71.0" N="176" name="Lu176">
+            <atom value="175.943" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Lu">
+            <fraction n="0.9741" ref="Lu175"/>
+            <fraction n="0.0259" ref="Lu176"/>
+        </element>
+        <isotope Z="72.0" N="174" name="Hf174">
+            <atom value="173.94" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="176" name="Hf176">
+            <atom value="175.941" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="177" name="Hf177">
+            <atom value="176.943" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="178" name="Hf178">
+            <atom value="177.944" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="179" name="Hf179">
+            <atom value="178.946" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="72.0" N="180" name="Hf180">
+            <atom value="179.947" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Hf">
+            <fraction n="0.0016" ref="Hf174"/>
+            <fraction n="0.0526" ref="Hf176"/>
+            <fraction n="0.186" ref="Hf177"/>
+            <fraction n="0.2728" ref="Hf178"/>
+            <fraction n="0.1362" ref="Hf179"/>
+            <fraction n="0.3508" ref="Hf180"/>
+        </element>
+        <isotope Z="73.0" N="180" name="Ta180">
+            <atom value="179.947" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="73.0" N="181" name="Ta181">
+            <atom value="180.948" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ta">
+            <fraction n="1.2E-4" ref="Ta180"/>
+            <fraction n="0.99988" ref="Ta181"/>
+        </element>
+        <isotope Z="74.0" N="180" name="W180">
+            <atom value="179.947" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="182" name="W182">
+            <atom value="181.948" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="183" name="W183">
+            <atom value="182.95" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="184" name="W184">
+            <atom value="183.951" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="74.0" N="186" name="W186">
+            <atom value="185.954" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="W">
+            <fraction n="0.0012" ref="W180"/>
+            <fraction n="0.265" ref="W182"/>
+            <fraction n="0.1431" ref="W183"/>
+            <fraction n="0.3064" ref="W184"/>
+            <fraction n="0.2843" ref="W186"/>
+        </element>
+        <isotope Z="75.0" N="185" name="Re185">
+            <atom value="184.953" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="75.0" N="187" name="Re187">
+            <atom value="186.956" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Re">
+            <fraction n="0.374" ref="Re185"/>
+            <fraction n="0.626" ref="Re187"/>
+        </element>
+        <isotope Z="76.0" N="184" name="Os184">
+            <atom value="183.952" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="186" name="Os186">
+            <atom value="185.954" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="187" name="Os187">
+            <atom value="186.956" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="188" name="Os188">
+            <atom value="187.956" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="189" name="Os189">
+            <atom value="188.958" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="190" name="Os190">
+            <atom value="189.958" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="76.0" N="192" name="Os192">
+            <atom value="191.961" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Os">
+            <fraction n="2.0E-4" ref="Os184"/>
+            <fraction n="0.0159" ref="Os186"/>
+            <fraction n="0.0196" ref="Os187"/>
+            <fraction n="0.1324" ref="Os188"/>
+            <fraction n="0.1615" ref="Os189"/>
+            <fraction n="0.2626" ref="Os190"/>
+            <fraction n="0.4078" ref="Os192"/>
+        </element>
+        <isotope Z="77.0" N="191" name="Ir191">
+            <atom value="190.961" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="77.0" N="193" name="Ir193">
+            <atom value="192.963" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ir">
+            <fraction n="0.373" ref="Ir191"/>
+            <fraction n="0.627" ref="Ir193"/>
+        </element>
+        <isotope Z="78.0" N="190" name="Pt190">
+            <atom value="189.96" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="192" name="Pt192">
+            <atom value="191.961" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="194" name="Pt194">
+            <atom value="193.963" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="195" name="Pt195">
+            <atom value="194.965" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="196" name="Pt196">
+            <atom value="195.965" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="78.0" N="198" name="Pt198">
+            <atom value="197.968" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pt">
+            <fraction n="1.4E-4" ref="Pt190"/>
+            <fraction n="0.00782" ref="Pt192"/>
+            <fraction n="0.32967" ref="Pt194"/>
+            <fraction n="0.33832" ref="Pt195"/>
+            <fraction n="0.25242" ref="Pt196"/>
+            <fraction n="0.07163" ref="Pt198"/>
+        </element>
+        <isotope Z="79.0" N="197" name="Au197">
+            <atom value="196.967" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Au">
+            <fraction n="1.0" ref="Au197"/>
+        </element>
+        <isotope Z="80.0" N="196" name="Hg196">
+            <atom value="195.966" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="198" name="Hg198">
+            <atom value="197.967" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="199" name="Hg199">
+            <atom value="198.968" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="200" name="Hg200">
+            <atom value="199.968" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="201" name="Hg201">
+            <atom value="200.97" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="202" name="Hg202">
+            <atom value="201.971" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="80.0" N="204" name="Hg204">
+            <atom value="203.973" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Hg">
+            <fraction n="0.0015" ref="Hg196"/>
+            <fraction n="0.0997" ref="Hg198"/>
+            <fraction n="0.1687" ref="Hg199"/>
+            <fraction n="0.231" ref="Hg200"/>
+            <fraction n="0.1318" ref="Hg201"/>
+            <fraction n="0.2986" ref="Hg202"/>
+            <fraction n="0.0687" ref="Hg204"/>
+        </element>
+        <isotope Z="81.0" N="203" name="Tl203">
+            <atom value="202.972" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="81.0" N="205" name="Tl205">
+            <atom value="204.974" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Tl">
+            <fraction n="0.29524" ref="Tl203"/>
+            <fraction n="0.70476" ref="Tl205"/>
+        </element>
+        <isotope Z="82.0" N="204" name="Pb204">
+            <atom value="203.973" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="206" name="Pb206">
+            <atom value="205.974" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="207" name="Pb207">
+            <atom value="206.976" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="82.0" N="208" name="Pb208">
+            <atom value="207.977" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pb">
+            <fraction n="0.014" ref="Pb204"/>
+            <fraction n="0.241" ref="Pb206"/>
+            <fraction n="0.221" ref="Pb207"/>
+            <fraction n="0.524" ref="Pb208"/>
+        </element>
+        <isotope Z="83.0" N="209" name="Bi209">
+            <atom value="208.98" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Bi">
+            <fraction n="1.0" ref="Bi209"/>
+        </element>
+        <isotope Z="84.0" N="209" name="Po209">
+            <atom value="208.982" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Po">
+            <fraction n="1.0" ref="Po209"/>
+        </element>
+        <isotope Z="85.0" N="210" name="At210">
+            <atom value="209.987" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="At">
+            <fraction n="1.0" ref="At210"/>
+        </element>
+        <isotope Z="86.0" N="222" name="Rn222">
+            <atom value="222.018" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Rn">
+            <fraction n="1.0" ref="Rn222"/>
+        </element>
+        <isotope Z="87.0" N="223" name="Fr223">
+            <atom value="223.02" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Fr">
+            <fraction n="1.0" ref="Fr223"/>
+        </element>
+        <isotope Z="88.0" N="226" name="Ra226">
+            <atom value="226.025" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ra">
+            <fraction n="1.0" ref="Ra226"/>
+        </element>
+        <isotope Z="89.0" N="227" name="Ac227">
+            <atom value="227.028" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Ac">
+            <fraction n="1.0" ref="Ac227"/>
+        </element>
+        <isotope Z="90.0" N="232" name="Th232">
+            <atom value="232.038" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Th">
+            <fraction n="1.0" ref="Th232"/>
+        </element>
+        <isotope Z="91.0" N="231" name="Pa231">
+            <atom value="231.036" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="Pa">
+            <fraction n="1.0" ref="Pa231"/>
+        </element>
+        <isotope Z="92.0" N="234" name="U234">
+            <atom value="234.041" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="92.0" N="235" name="U235">
+            <atom value="235.044" unit="g/mole" type="A"/>
+        </isotope>
+        <isotope Z="92.0" N="238" name="U238">
+            <atom value="238.051" unit="g/mole" type="A"/>
+        </isotope>
+        <element name="U">
+            <fraction n="5.5E-5" ref="U234"/>
+            <fraction n="0.0072" ref="U235"/>
+            <fraction n="0.992745" ref="U238"/>
+        </element>
+        <material state="solid" name="G4_WATER">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.111898" ref="H"/>
+            <fraction n="0.888102" ref="O"/>
+        </material>
+        <material state="gas" name="G4_H">
+            <D value="0.083748" unit="kg/m3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="gas" name="G4_He">
+            <D value="0.166322" unit="kg/m3"/>
+            <fraction n="1.0" ref="He"/>
+        </material>
+        <material state="solid" name="G4_Li">
+            <D value="0.534" unit="g/cm3"/>
+            <fraction n="1.0" ref="Li"/>
+        </material>
+        <material state="solid" name="G4_Be">
+            <D value="1.848" unit="g/cm3"/>
+            <fraction n="1.0" ref="Be"/>
+        </material>
+        <material state="solid" name="G4_B">
+            <D value="2.37" unit="g/cm3"/>
+            <fraction n="1.0" ref="B"/>
+        </material>
+        <material state="solid" name="G4_C">
+            <D value="2.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="C"/>
+        </material>
+        <material state="gas" name="G4_N">
+            <D value="1.1652" unit="kg/m3"/>
+            <fraction n="1.0" ref="N"/>
+        </material>
+        <material state="gas" name="G4_O">
+            <D value="1.33151" unit="kg/m3"/>
+            <fraction n="1.0" ref="O"/>
+        </material>
+        <material state="gas" name="G4_F">
+            <D value="1.58029" unit="kg/m3"/>
+            <fraction n="1.0" ref="F"/>
+        </material>
+        <material state="gas" name="G4_Ne">
+            <D value="0.838505" unit="kg/m3"/>
+            <fraction n="1.0" ref="Ne"/>
+        </material>
+        <material state="solid" name="G4_Na">
+            <D value="0.971" unit="g/cm3"/>
+            <fraction n="1.0" ref="Na"/>
+        </material>
+        <material state="solid" name="G4_Mg">
+            <D value="1.74" unit="g/cm3"/>
+            <fraction n="1.0" ref="Mg"/>
+        </material>
+        <material state="solid" name="G4_Al">
+            <D value="2.699" unit="g/cm3"/>
+            <fraction n="1.0" ref="Al"/>
+        </material>
+        <material state="solid" name="G4_Si">
+            <D value="2.33" unit="g/cm3"/>
+            <fraction n="1.0" ref="Si"/>
+        </material>
+        <material state="solid" name="G4_P">
+            <D value="2.2" unit="g/cm3"/>
+            <fraction n="1.0" ref="P"/>
+        </material>
+        <material state="solid" name="G4_S">
+            <D value="2.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="S"/>
+        </material>
+        <material state="gas" name="G4_Cl">
+            <D value="2.99473" unit="kg/m3"/>
+            <fraction n="1.0" ref="Cl"/>
+        </material>
+        <material state="gas" name="G4_Ar">
+            <D value="1.66201" unit="kg/m3"/>
+            <fraction n="1.0" ref="Ar"/>
+        </material>
+        <material state="solid" name="G4_K">
+            <D value="0.862" unit="g/cm3"/>
+            <fraction n="1.0" ref="K"/>
+        </material>
+        <material state="solid" name="G4_Ca">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_Sc">
+            <D value="2.989" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sc"/>
+        </material>
+        <material state="solid" name="G4_Ti">
+            <D value="4.54" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ti"/>
+        </material>
+        <material state="solid" name="G4_V">
+            <D value="6.11" unit="g/cm3"/>
+            <fraction n="1.0" ref="V"/>
+        </material>
+        <material state="solid" name="G4_Cr">
+            <D value="7.18" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cr"/>
+        </material>
+        <material state="solid" name="G4_Mn">
+            <D value="7.44" unit="g/cm3"/>
+            <fraction n="1.0" ref="Mn"/>
+        </material>
+        <material state="solid" name="G4_Fe">
+            <D value="7.874" unit="g/cm3"/>
+            <fraction n="1.0" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_Co">
+            <D value="8.9" unit="g/cm3"/>
+            <fraction n="1.0" ref="Co"/>
+        </material>
+        <material state="solid" name="G4_Ni">
+            <D value="8.902" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ni"/>
+        </material>
+        <material state="solid" name="G4_Cu">
+            <D value="8.96" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cu"/>
+        </material>
+        <material state="solid" name="G4_Zn">
+            <D value="7.133" unit="g/cm3"/>
+            <fraction n="1.0" ref="Zn"/>
+        </material>
+        <material state="solid" name="G4_Ga">
+            <D value="5.904" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ga"/>
+        </material>
+        <material state="solid" name="G4_Ge">
+            <D value="5.323" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ge"/>
+        </material>
+        <material state="solid" name="G4_As">
+            <D value="5.73" unit="g/cm3"/>
+            <fraction n="1.0" ref="As"/>
+        </material>
+        <material state="solid" name="G4_Se">
+            <D value="4.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Se"/>
+        </material>
+        <material state="gas" name="G4_Br">
+            <D value="7.0721" unit="kg/m3"/>
+            <fraction n="1.0" ref="Br"/>
+        </material>
+        <material state="gas" name="G4_Kr">
+            <D value="3.47832" unit="kg/m3"/>
+            <fraction n="1.0" ref="Kr"/>
+        </material>
+        <material state="solid" name="G4_Rb">
+            <D value="1.532" unit="g/cm3"/>
+            <fraction n="1.0" ref="Rb"/>
+        </material>
+        <material state="solid" name="G4_Sr">
+            <D value="2.54" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sr"/>
+        </material>
+        <material state="solid" name="G4_Y">
+            <D value="4.469" unit="g/cm3"/>
+            <fraction n="1.0" ref="Y"/>
+        </material>
+        <material state="solid" name="G4_Zr">
+            <D value="6.506" unit="g/cm3"/>
+            <fraction n="1.0" ref="Zr"/>
+        </material>
+        <material state="solid" name="G4_Nb">
+            <D value="8.57" unit="g/cm3"/>
+            <fraction n="1.0" ref="Nb"/>
+        </material>
+        <material state="solid" name="G4_Mo">
+            <D value="10.22" unit="g/cm3"/>
+            <fraction n="1.0" ref="Mo"/>
+        </material>
+        <material state="solid" name="G4_Tc">
+            <D value="11.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tc"/>
+        </material>
+        <material state="solid" name="G4_Ru">
+            <D value="12.41" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ru"/>
+        </material>
+        <material state="solid" name="G4_Rh">
+            <D value="12.41" unit="g/cm3"/>
+            <fraction n="1.0" ref="Rh"/>
+        </material>
+        <material state="solid" name="G4_Pd">
+            <D value="12.02" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pd"/>
+        </material>
+        <material state="solid" name="G4_Ag">
+            <D value="10.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ag"/>
+        </material>
+        <material state="solid" name="G4_Cd">
+            <D value="8.65" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cd"/>
+        </material>
+        <material state="solid" name="G4_In">
+            <D value="7.31" unit="g/cm3"/>
+            <fraction n="1.0" ref="In"/>
+        </material>
+        <material state="solid" name="G4_Sn">
+            <D value="7.31" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sn"/>
+        </material>
+        <material state="solid" name="G4_Sb">
+            <D value="6.691" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sb"/>
+        </material>
+        <material state="solid" name="G4_Te">
+            <D value="6.24" unit="g/cm3"/>
+            <fraction n="1.0" ref="Te"/>
+        </material>
+        <material state="solid" name="G4_I">
+            <D value="4.93" unit="g/cm3"/>
+            <fraction n="1.0" ref="I"/>
+        </material>
+        <material state="gas" name="G4_Xe">
+            <D value="5.48536" unit="kg/m3"/>
+            <fraction n="1.0" ref="Xe"/>
+        </material>
+        <material state="solid" name="G4_Cs">
+            <D value="1.873" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cs"/>
+        </material>
+        <material state="solid" name="G4_Ba">
+            <D value="3.5" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ba"/>
+        </material>
+        <material state="solid" name="G4_La">
+            <D value="6.154" unit="g/cm3"/>
+            <fraction n="1.0" ref="La"/>
+        </material>
+        <material state="solid" name="G4_Ce">
+            <D value="6.657" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ce"/>
+        </material>
+        <material state="solid" name="G4_Pr">
+            <D value="6.71" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pr"/>
+        </material>
+        <material state="solid" name="G4_Nd">
+            <D value="6.9" unit="g/cm3"/>
+            <fraction n="1.0" ref="Nd"/>
+        </material>
+        <material state="solid" name="G4_Pm">
+            <D value="7.22" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pm"/>
+        </material>
+        <material state="solid" name="G4_Sm">
+            <D value="7.46" unit="g/cm3"/>
+            <fraction n="1.0" ref="Sm"/>
+        </material>
+        <material state="solid" name="G4_Eu">
+            <D value="5.243" unit="g/cm3"/>
+            <fraction n="1.0" ref="Eu"/>
+        </material>
+        <material state="solid" name="G4_Gd">
+            <D value="7.9004" unit="g/cm3"/>
+            <fraction n="1.0" ref="Gd"/>
+        </material>
+        <material state="solid" name="G4_Tb">
+            <D value="8.229" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tb"/>
+        </material>
+        <material state="solid" name="G4_Dy">
+            <D value="8.55" unit="g/cm3"/>
+            <fraction n="1.0" ref="Dy"/>
+        </material>
+        <material state="solid" name="G4_Ho">
+            <D value="8.795" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ho"/>
+        </material>
+        <material state="solid" name="G4_Er">
+            <D value="9.066" unit="g/cm3"/>
+            <fraction n="1.0" ref="Er"/>
+        </material>
+        <material state="solid" name="G4_Tm">
+            <D value="9.321" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tm"/>
+        </material>
+        <material state="solid" name="G4_Yb">
+            <D value="6.73" unit="g/cm3"/>
+            <fraction n="1.0" ref="Yb"/>
+        </material>
+        <material state="solid" name="G4_Lu">
+            <D value="9.84" unit="g/cm3"/>
+            <fraction n="1.0" ref="Lu"/>
+        </material>
+        <material state="solid" name="G4_Hf">
+            <D value="13.31" unit="g/cm3"/>
+            <fraction n="1.0" ref="Hf"/>
+        </material>
+        <material state="solid" name="G4_Ta">
+            <D value="16.654" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ta"/>
+        </material>
+        <material state="solid" name="G4_W">
+            <D value="19.3" unit="g/cm3"/>
+            <fraction n="1.0" ref="W"/>
+        </material>
+        <material state="solid" name="G4_Re">
+            <D value="21.02" unit="g/cm3"/>
+            <fraction n="1.0" ref="Re"/>
+        </material>
+        <material state="solid" name="G4_Os">
+            <D value="22.57" unit="g/cm3"/>
+            <fraction n="1.0" ref="Os"/>
+        </material>
+        <material state="solid" name="G4_Ir">
+            <D value="22.42" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ir"/>
+        </material>
+        <material state="solid" name="G4_Pt">
+            <D value="21.45" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pt"/>
+        </material>
+        <material state="solid" name="G4_Au">
+            <D value="19.32" unit="g/cm3"/>
+            <fraction n="1.0" ref="Au"/>
+        </material>
+        <material state="solid" name="G4_Hg">
+            <D value="13.546" unit="g/cm3"/>
+            <fraction n="1.0" ref="Hg"/>
+        </material>
+        <material state="solid" name="G4_Tl">
+            <D value="11.72" unit="g/cm3"/>
+            <fraction n="1.0" ref="Tl"/>
+        </material>
+        <material state="solid" name="G4_Pb">
+            <D value="11.35" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_Bi">
+            <D value="9.747" unit="g/cm3"/>
+            <fraction n="1.0" ref="Bi"/>
+        </material>
+        <material state="solid" name="G4_Po">
+            <D value="9.32" unit="g/cm3"/>
+            <fraction n="1.0" ref="Po"/>
+        </material>
+        <material state="solid" name="G4_At">
+            <D value="9.32" unit="g/cm3"/>
+            <fraction n="1.0" ref="At"/>
+        </material>
+        <material state="gas" name="G4_Rn">
+            <D value="9.00662" unit="kg/m3"/>
+            <fraction n="1.0" ref="Rn"/>
+        </material>
+        <material state="solid" name="G4_Fr">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Fr"/>
+        </material>
+        <material state="solid" name="G4_Ra">
+            <D value="5.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ra"/>
+        </material>
+        <material state="solid" name="G4_Ac">
+            <D value="10.07" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ac"/>
+        </material>
+        <material state="solid" name="G4_Th">
+            <D value="11.72" unit="g/cm3"/>
+            <fraction n="1.0" ref="Th"/>
+        </material>
+        <material state="solid" name="G4_Pa">
+            <D value="15.37" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pa"/>
+        </material>
+        <material state="solid" name="G4_U">
+            <D value="18.95" unit="g/cm3"/>
+            <fraction n="1.0" ref="U"/>
+        </material>
+        <material state="solid" name="G4_Np">
+            <D value="20.25" unit="g/cm3"/>
+            <fraction n="1.0" ref="Np"/>
+        </material>
+        <material state="solid" name="G4_Pu">
+            <D value="19.84" unit="g/cm3"/>
+            <fraction n="1.0" ref="Pu"/>
+        </material>
+        <material state="solid" name="G4_Am">
+            <D value="13.67" unit="g/cm3"/>
+            <fraction n="1.0" ref="Am"/>
+        </material>
+        <material state="solid" name="G4_Cm">
+            <D value="13.51" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cm"/>
+        </material>
+        <material state="solid" name="G4_Bk">
+            <D value="14.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Bk"/>
+        </material>
+        <material state="solid" name="G4_Cf">
+            <D value="10.0" unit="g/cm3"/>
+            <fraction n="1.0" ref="Cf"/>
+        </material>
+        <material state="solid" name="G4_A-150_TISSUE">
+            <D value="1.127" unit="g/cm3"/>
+            <fraction n="0.101327" ref="H"/>
+            <fraction n="0.7755" ref="C"/>
+            <fraction n="0.035057" ref="N"/>
+            <fraction n="0.052316" ref="O"/>
+            <fraction n="0.017422" ref="F"/>
+            <fraction n="0.018378" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_ACETONE">
+            <D value="0.7899" unit="g/cm3"/>
+            <fraction n="0.620397" ref="C"/>
+            <fraction n="0.104127" ref="H"/>
+            <fraction n="0.275475" ref="O"/>
+        </material>
+        <material state="gas" name="G4_ACETYLENE">
+            <D value="1.0967" unit="kg/m3"/>
+            <fraction n="0.922577" ref="C"/>
+            <fraction n="0.077423" ref="H"/>
+        </material>
+        <material state="solid" name="G4_ADENINE">
+            <D value="1.6" unit="g/cm3"/>
+            <fraction n="0.444423" ref="C"/>
+            <fraction n="0.037296" ref="H"/>
+            <fraction n="0.518281" ref="N"/>
+        </material>
+        <material state="solid" name="G4_ADIPOSE_TISSUE_ICRP">
+            <D value="0.95" unit="g/cm3"/>
+            <fraction n="0.114" ref="H"/>
+            <fraction n="0.598" ref="C"/>
+            <fraction n="0.007" ref="N"/>
+            <fraction n="0.278" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+        </material>
+        <material state="gas" name="G4_AIR">
+            <D value="1.20479" unit="kg/m3"/>
+            <fraction n="1.24E-4" ref="C"/>
+            <fraction n="0.755268" ref="N"/>
+            <fraction n="0.231781" ref="O"/>
+            <fraction n="0.012827" ref="Ar"/>
+        </material>
+        <material state="solid" name="G4_ALANINE">
+            <D value="1.42" unit="g/cm3"/>
+            <fraction n="0.404432" ref="C"/>
+            <fraction n="0.079193" ref="H"/>
+            <fraction n="0.157215" ref="N"/>
+            <fraction n="0.35916" ref="O"/>
+        </material>
+        <material state="solid" name="G4_ALUMINUM_OXIDE">
+            <D value="3.97" unit="g/cm3"/>
+            <fraction n="0.52925" ref="Al"/>
+            <fraction n="0.47075" ref="O"/>
+        </material>
+        <material state="solid" name="G4_AMBER">
+            <D value="1.1" unit="g/cm3"/>
+            <fraction n="0.10593" ref="H"/>
+            <fraction n="0.788974" ref="C"/>
+            <fraction n="0.105096" ref="O"/>
+        </material>
+        <material state="gas" name="G4_AMMONIA">
+            <D value="0.826019" unit="kg/m3"/>
+            <fraction n="0.822448" ref="N"/>
+            <fraction n="0.177552" ref="H"/>
+        </material>
+        <material state="solid" name="G4_ANILINE">
+            <D value="1.0235" unit="g/cm3"/>
+            <fraction n="0.773831" ref="C"/>
+            <fraction n="0.075763" ref="H"/>
+            <fraction n="0.150405" ref="N"/>
+        </material>
+        <material state="solid" name="G4_ANTHRACENE">
+            <D value="1.283" unit="g/cm3"/>
+            <fraction n="0.943447" ref="C"/>
+            <fraction n="0.056553" ref="H"/>
+        </material>
+        <material state="solid" name="G4_B-100_BONE">
+            <D value="1.45" unit="g/cm3"/>
+            <fraction n="0.065471" ref="H"/>
+            <fraction n="0.536944" ref="C"/>
+            <fraction n="0.0215" ref="N"/>
+            <fraction n="0.032085" ref="O"/>
+            <fraction n="0.167411" ref="F"/>
+            <fraction n="0.176589" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_BAKELITE">
+            <D value="1.25" unit="g/cm3"/>
+            <fraction n="0.057441" ref="H"/>
+            <fraction n="0.774591" ref="C"/>
+            <fraction n="0.167968" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BARIUM_FLUORIDE">
+            <D value="4.89" unit="g/cm3"/>
+            <fraction n="0.783276" ref="Ba"/>
+            <fraction n="0.216724" ref="F"/>
+        </material>
+        <material state="solid" name="G4_BARIUM_SULFATE">
+            <D value="4.5" unit="g/cm3"/>
+            <fraction n="0.588399" ref="Ba"/>
+            <fraction n="0.137393" ref="S"/>
+            <fraction n="0.274208" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BENZENE">
+            <D value="0.87865" unit="g/cm3"/>
+            <fraction n="0.922577" ref="C"/>
+            <fraction n="0.077423" ref="H"/>
+        </material>
+        <material state="solid" name="G4_BERYLLIUM_OXIDE">
+            <D value="3.01" unit="g/cm3"/>
+            <fraction n="0.36032" ref="Be"/>
+            <fraction n="0.63968" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BGO">
+            <D value="7.13" unit="g/cm3"/>
+            <fraction n="0.671017" ref="Bi"/>
+            <fraction n="0.174865" ref="Ge"/>
+            <fraction n="0.154118" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BLOOD_ICRP">
+            <D value="1.06" unit="g/cm3"/>
+            <fraction n="0.102" ref="H"/>
+            <fraction n="0.11" ref="C"/>
+            <fraction n="0.033" ref="N"/>
+            <fraction n="0.745" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+            <fraction n="0.001" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_BONE_COMPACT_ICRU">
+            <D value="1.85" unit="g/cm3"/>
+            <fraction n="0.064" ref="H"/>
+            <fraction n="0.278" ref="C"/>
+            <fraction n="0.027" ref="N"/>
+            <fraction n="0.41" ref="O"/>
+            <fraction n="0.002" ref="Mg"/>
+            <fraction n="0.07" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.147" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_BONE_CORTICAL_ICRP">
+            <D value="1.92" unit="g/cm3"/>
+            <fraction n="0.034" ref="H"/>
+            <fraction n="0.155" ref="C"/>
+            <fraction n="0.042" ref="N"/>
+            <fraction n="0.435" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.002" ref="Mg"/>
+            <fraction n="0.103" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.225" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_BORON_CARBIDE">
+            <D value="2.52" unit="g/cm3"/>
+            <fraction n="0.78263" ref="B"/>
+            <fraction n="0.21737" ref="C"/>
+        </material>
+        <material state="solid" name="G4_BORON_OXIDE">
+            <D value="1.812" unit="g/cm3"/>
+            <fraction n="0.310571" ref="B"/>
+            <fraction n="0.689429" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BRAIN_ICRP">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.107" ref="H"/>
+            <fraction n="0.145" ref="C"/>
+            <fraction n="0.022" ref="N"/>
+            <fraction n="0.712" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.004" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.003" ref="K"/>
+        </material>
+        <material state="gas" name="G4_BUTANE">
+            <D value="2.49343" unit="kg/m3"/>
+            <fraction n="0.826583" ref="C"/>
+            <fraction n="0.173417" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-BUTYL_ALCOHOL">
+            <D value="0.8098" unit="g/cm3"/>
+            <fraction n="0.648163" ref="C"/>
+            <fraction n="0.135984" ref="H"/>
+            <fraction n="0.215853" ref="O"/>
+        </material>
+        <material state="solid" name="G4_C-552">
+            <D value="1.76" unit="g/cm3"/>
+            <fraction n="0.02468" ref="H"/>
+            <fraction n="0.501611" ref="C"/>
+            <fraction n="0.004527" ref="O"/>
+            <fraction n="0.465209" ref="F"/>
+            <fraction n="0.003973" ref="Si"/>
+        </material>
+        <material state="solid" name="G4_CADMIUM_TELLURIDE">
+            <D value="6.2" unit="g/cm3"/>
+            <fraction n="0.468353" ref="Cd"/>
+            <fraction n="0.531647" ref="Te"/>
+        </material>
+        <material state="solid" name="G4_CADMIUM_TUNGSTATE">
+            <D value="7.9" unit="g/cm3"/>
+            <fraction n="0.312037" ref="Cd"/>
+            <fraction n="0.510316" ref="W"/>
+            <fraction n="0.177647" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_CARBONATE">
+            <D value="2.8" unit="g/cm3"/>
+            <fraction n="0.400432" ref="Ca"/>
+            <fraction n="0.120003" ref="C"/>
+            <fraction n="0.479565" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_FLUORIDE">
+            <D value="3.18" unit="g/cm3"/>
+            <fraction n="0.513328" ref="Ca"/>
+            <fraction n="0.486672" ref="F"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_OXIDE">
+            <D value="3.3" unit="g/cm3"/>
+            <fraction n="0.714691" ref="Ca"/>
+            <fraction n="0.285309" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_SULFATE">
+            <D value="2.96" unit="g/cm3"/>
+            <fraction n="0.294385" ref="Ca"/>
+            <fraction n="0.235535" ref="S"/>
+            <fraction n="0.47008" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CALCIUM_TUNGSTATE">
+            <D value="6.062" unit="g/cm3"/>
+            <fraction n="0.1392" ref="Ca"/>
+            <fraction n="0.638522" ref="W"/>
+            <fraction n="0.222278" ref="O"/>
+        </material>
+        <material state="gas" name="G4_CARBON_DIOXIDE">
+            <D value="1.84212" unit="kg/m3"/>
+            <fraction n="0.272912" ref="C"/>
+            <fraction n="0.727088" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CARBON_TETRACHLORIDE">
+            <D value="1.594" unit="g/cm3"/>
+            <fraction n="0.078083" ref="C"/>
+            <fraction n="0.921917" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CELLULOSE_CELLOPHANE">
+            <D value="1.42" unit="g/cm3"/>
+            <fraction n="0.444456" ref="C"/>
+            <fraction n="0.062165" ref="H"/>
+            <fraction n="0.49338" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CELLULOSE_BUTYRATE">
+            <D value="1.2" unit="g/cm3"/>
+            <fraction n="0.067125" ref="H"/>
+            <fraction n="0.545403" ref="C"/>
+            <fraction n="0.387472" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CELLULOSE_NITRATE">
+            <D value="1.49" unit="g/cm3"/>
+            <fraction n="0.029216" ref="H"/>
+            <fraction n="0.271296" ref="C"/>
+            <fraction n="0.121276" ref="N"/>
+            <fraction n="0.578212" ref="O"/>
+        </material>
+        <material state="solid" name="G4_CERIC_SULFATE">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.107596" ref="H"/>
+            <fraction n="8.0E-4" ref="N"/>
+            <fraction n="0.874976" ref="O"/>
+            <fraction n="0.014627" ref="S"/>
+            <fraction n="0.002001" ref="Ce"/>
+        </material>
+        <material state="solid" name="G4_CESIUM_FLUORIDE">
+            <D value="4.115" unit="g/cm3"/>
+            <fraction n="0.874931" ref="Cs"/>
+            <fraction n="0.125069" ref="F"/>
+        </material>
+        <material state="solid" name="G4_CESIUM_IODIDE">
+            <D value="4.51" unit="g/cm3"/>
+            <fraction n="0.511549" ref="Cs"/>
+            <fraction n="0.488451" ref="I"/>
+        </material>
+        <material state="solid" name="G4_CHLOROBENZENE">
+            <D value="1.1058" unit="g/cm3"/>
+            <fraction n="0.64025" ref="C"/>
+            <fraction n="0.044775" ref="H"/>
+            <fraction n="0.314975" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CHLOROFORM">
+            <D value="1.4832" unit="g/cm3"/>
+            <fraction n="0.100612" ref="C"/>
+            <fraction n="0.008443" ref="H"/>
+            <fraction n="0.890944" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CONCRETE">
+            <D value="2.3" unit="g/cm3"/>
+            <fraction n="0.01" ref="H"/>
+            <fraction n="0.001" ref="C"/>
+            <fraction n="0.529107" ref="O"/>
+            <fraction n="0.016" ref="Na"/>
+            <fraction n="0.002" ref="Mg"/>
+            <fraction n="0.033872" ref="Al"/>
+            <fraction n="0.337021" ref="Si"/>
+            <fraction n="0.013" ref="K"/>
+            <fraction n="0.044" ref="Ca"/>
+            <fraction n="0.014" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_CYCLOHEXANE">
+            <D value="0.779" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_1,2-DICHLOROBENZENE">
+            <D value="1.3048" unit="g/cm3"/>
+            <fraction n="0.49023" ref="C"/>
+            <fraction n="0.027427" ref="H"/>
+            <fraction n="0.482344" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_DICHLORODIETHYL_ETHER">
+            <D value="1.2199" unit="g/cm3"/>
+            <fraction n="0.335939" ref="C"/>
+            <fraction n="0.056384" ref="H"/>
+            <fraction n="0.111875" ref="O"/>
+            <fraction n="0.495802" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_1,2-DICHLOROETHANE">
+            <D value="1.2351" unit="g/cm3"/>
+            <fraction n="0.242743" ref="C"/>
+            <fraction n="0.040742" ref="H"/>
+            <fraction n="0.716515" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_DIETHYL_ETHER">
+            <D value="0.71378" unit="g/cm3"/>
+            <fraction n="0.648163" ref="C"/>
+            <fraction n="0.135984" ref="H"/>
+            <fraction n="0.215853" ref="O"/>
+        </material>
+        <material state="solid" name="G4_N,N-DIMETHYL_FORMAMIDE">
+            <D value="0.9487" unit="g/cm3"/>
+            <fraction n="0.492957" ref="C"/>
+            <fraction n="0.096528" ref="H"/>
+            <fraction n="0.191627" ref="N"/>
+            <fraction n="0.218888" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DIMETHYL_SULFOXIDE">
+            <D value="1.1014" unit="g/cm3"/>
+            <fraction n="0.307437" ref="C"/>
+            <fraction n="0.0774" ref="H"/>
+            <fraction n="0.204767" ref="O"/>
+            <fraction n="0.410396" ref="S"/>
+        </material>
+        <material state="gas" name="G4_ETHANE">
+            <D value="1.25324" unit="kg/m3"/>
+            <fraction n="0.798875" ref="C"/>
+            <fraction n="0.201125" ref="H"/>
+        </material>
+        <material state="solid" name="G4_ETHYL_ALCOHOL">
+            <D value="0.7893" unit="g/cm3"/>
+            <fraction n="0.521429" ref="C"/>
+            <fraction n="0.131275" ref="H"/>
+            <fraction n="0.347296" ref="O"/>
+        </material>
+        <material state="solid" name="G4_ETHYL_CELLULOSE">
+            <D value="1.13" unit="g/cm3"/>
+            <fraction n="0.090027" ref="H"/>
+            <fraction n="0.585182" ref="C"/>
+            <fraction n="0.324791" ref="O"/>
+        </material>
+        <material state="gas" name="G4_ETHYLENE">
+            <D value="1.17497" unit="kg/m3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_EYE_LENS_ICRP">
+            <D value="1.07" unit="g/cm3"/>
+            <fraction n="0.096" ref="H"/>
+            <fraction n="0.195" ref="C"/>
+            <fraction n="0.057" ref="N"/>
+            <fraction n="0.646" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_FERRIC_OXIDE">
+            <D value="5.2" unit="g/cm3"/>
+            <fraction n="0.699426" ref="Fe"/>
+            <fraction n="0.300574" ref="O"/>
+        </material>
+        <material state="solid" name="G4_FERROBORIDE">
+            <D value="7.15" unit="g/cm3"/>
+            <fraction n="0.837809" ref="Fe"/>
+            <fraction n="0.162191" ref="B"/>
+        </material>
+        <material state="solid" name="G4_FERROUS_OXIDE">
+            <D value="5.7" unit="g/cm3"/>
+            <fraction n="0.777305" ref="Fe"/>
+            <fraction n="0.222695" ref="O"/>
+        </material>
+        <material state="solid" name="G4_FERROUS_SULFATE">
+            <D value="1.024" unit="g/cm3"/>
+            <fraction n="0.108259" ref="H"/>
+            <fraction n="2.7E-5" ref="N"/>
+            <fraction n="0.878636" ref="O"/>
+            <fraction n="2.2E-5" ref="Na"/>
+            <fraction n="0.012968" ref="S"/>
+            <fraction n="3.4E-5" ref="Cl"/>
+            <fraction n="5.4E-5" ref="Fe"/>
+        </material>
+        <material state="solid" name="G4_FREON-12">
+            <D value="1.12" unit="g/cm3"/>
+            <fraction n="0.099335" ref="C"/>
+            <fraction n="0.314247" ref="F"/>
+            <fraction n="0.586418" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_FREON-12B2">
+            <D value="1.8" unit="g/cm3"/>
+            <fraction n="0.057245" ref="C"/>
+            <fraction n="0.181096" ref="F"/>
+            <fraction n="0.761659" ref="Br"/>
+        </material>
+        <material state="solid" name="G4_FREON-13">
+            <D value="0.95" unit="g/cm3"/>
+            <fraction n="0.114983" ref="C"/>
+            <fraction n="0.545621" ref="F"/>
+            <fraction n="0.339396" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_FREON-13B1">
+            <D value="1.5" unit="g/cm3"/>
+            <fraction n="0.080658" ref="C"/>
+            <fraction n="0.382751" ref="F"/>
+            <fraction n="0.536591" ref="Br"/>
+        </material>
+        <material state="solid" name="G4_FREON-13I1">
+            <D value="1.8" unit="g/cm3"/>
+            <fraction n="0.061309" ref="C"/>
+            <fraction n="0.290924" ref="F"/>
+            <fraction n="0.647767" ref="I"/>
+        </material>
+        <material state="solid" name="G4_GADOLINIUM_OXYSULFIDE">
+            <D value="7.44" unit="g/cm3"/>
+            <fraction n="0.830771" ref="Gd"/>
+            <fraction n="0.084526" ref="O"/>
+            <fraction n="0.084703" ref="S"/>
+        </material>
+        <material state="solid" name="G4_GALLIUM_ARSENIDE">
+            <D value="5.31" unit="g/cm3"/>
+            <fraction n="0.48203" ref="Ga"/>
+            <fraction n="0.51797" ref="As"/>
+        </material>
+        <material state="solid" name="G4_GEL_PHOTO_EMULSION">
+            <D value="1.2914" unit="g/cm3"/>
+            <fraction n="0.08118" ref="H"/>
+            <fraction n="0.41606" ref="C"/>
+            <fraction n="0.11124" ref="N"/>
+            <fraction n="0.38064" ref="O"/>
+            <fraction n="0.01088" ref="S"/>
+        </material>
+        <material state="solid" name="G4_Pyrex_Glass">
+            <D value="2.23" unit="g/cm3"/>
+            <fraction n="0.040064" ref="B"/>
+            <fraction n="0.539561" ref="O"/>
+            <fraction n="0.028191" ref="Na"/>
+            <fraction n="0.011644" ref="Al"/>
+            <fraction n="0.377219" ref="Si"/>
+            <fraction n="0.003321" ref="K"/>
+        </material>
+        <material state="solid" name="G4_GLASS_LEAD">
+            <D value="6.22" unit="g/cm3"/>
+            <fraction n="0.156453" ref="O"/>
+            <fraction n="0.080866" ref="Si"/>
+            <fraction n="0.008092" ref="Ti"/>
+            <fraction n="0.002651" ref="As"/>
+            <fraction n="0.751938" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_GLASS_PLATE">
+            <D value="2.4" unit="g/cm3"/>
+            <fraction n="0.4598" ref="O"/>
+            <fraction n="0.096441" ref="Na"/>
+            <fraction n="0.336553" ref="Si"/>
+            <fraction n="0.107205" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_GLUTAMINE">
+            <D value="1.46" unit="g/cm3"/>
+            <fraction n="0.410919" ref="C"/>
+            <fraction n="0.068969" ref="H"/>
+            <fraction n="0.191683" ref="N"/>
+            <fraction n="0.328429" ref="O"/>
+        </material>
+        <material state="solid" name="G4_GLYCEROL">
+            <D value="1.2613" unit="g/cm3"/>
+            <fraction n="0.391255" ref="C"/>
+            <fraction n="0.087558" ref="H"/>
+            <fraction n="0.521187" ref="O"/>
+        </material>
+        <material state="solid" name="G4_GUANINE">
+            <D value="2.2" unit="g/cm3"/>
+            <fraction n="0.397373" ref="C"/>
+            <fraction n="0.033348" ref="H"/>
+            <fraction n="0.463412" ref="N"/>
+            <fraction n="0.105867" ref="O"/>
+        </material>
+        <material state="solid" name="G4_GYPSUM">
+            <D value="2.32" unit="g/cm3"/>
+            <fraction n="0.232779" ref="Ca"/>
+            <fraction n="0.186244" ref="S"/>
+            <fraction n="0.55756" ref="O"/>
+            <fraction n="0.023417" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-HEPTANE">
+            <D value="0.68376" unit="g/cm3"/>
+            <fraction n="0.839055" ref="C"/>
+            <fraction n="0.160945" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-HEXANE">
+            <D value="0.6603" unit="g/cm3"/>
+            <fraction n="0.836251" ref="C"/>
+            <fraction n="0.163749" ref="H"/>
+        </material>
+        <material state="solid" name="G4_KAPTON">
+            <D value="1.42" unit="g/cm3"/>
+            <fraction n="0.691128" ref="C"/>
+            <fraction n="0.026363" ref="H"/>
+            <fraction n="0.073271" ref="N"/>
+            <fraction n="0.209237" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LANTHANUM_OXYBROMIDE">
+            <D value="6.28" unit="g/cm3"/>
+            <fraction n="0.591569" ref="La"/>
+            <fraction n="0.340293" ref="Br"/>
+            <fraction n="0.068138" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LANTHANUM_OXYSULFIDE">
+            <D value="5.86" unit="g/cm3"/>
+            <fraction n="0.812607" ref="La"/>
+            <fraction n="0.093598" ref="O"/>
+            <fraction n="0.093795" ref="S"/>
+        </material>
+        <material state="solid" name="G4_LEAD_OXIDE">
+            <D value="9.53" unit="g/cm3"/>
+            <fraction n="0.071682" ref="O"/>
+            <fraction n="0.928318" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_AMIDE">
+            <D value="1.178" unit="g/cm3"/>
+            <fraction n="0.302231" ref="Li"/>
+            <fraction n="0.60998" ref="N"/>
+            <fraction n="0.087789" ref="H"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_CARBONATE">
+            <D value="2.11" unit="g/cm3"/>
+            <fraction n="0.18785" ref="Li"/>
+            <fraction n="0.162551" ref="C"/>
+            <fraction n="0.649599" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_FLUORIDE">
+            <D value="2.635" unit="g/cm3"/>
+            <fraction n="0.267558" ref="Li"/>
+            <fraction n="0.732442" ref="F"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_HYDRIDE">
+            <D value="0.82" unit="g/cm3"/>
+            <fraction n="0.873183" ref="Li"/>
+            <fraction n="0.126817" ref="H"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_IODIDE">
+            <D value="3.494" unit="g/cm3"/>
+            <fraction n="0.051852" ref="Li"/>
+            <fraction n="0.948148" ref="I"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_OXIDE">
+            <D value="2.013" unit="g/cm3"/>
+            <fraction n="0.464535" ref="Li"/>
+            <fraction n="0.535465" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LITHIUM_TETRABORATE">
+            <D value="2.44" unit="g/cm3"/>
+            <fraction n="0.082072" ref="Li"/>
+            <fraction n="0.255701" ref="B"/>
+            <fraction n="0.662227" ref="O"/>
+        </material>
+        <material state="solid" name="G4_LUNG_ICRP">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.105" ref="H"/>
+            <fraction n="0.083" ref="C"/>
+            <fraction n="0.023" ref="N"/>
+            <fraction n="0.779" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_M3_WAX">
+            <D value="1.05" unit="g/cm3"/>
+            <fraction n="0.114318" ref="H"/>
+            <fraction n="0.655824" ref="C"/>
+            <fraction n="0.092183" ref="O"/>
+            <fraction n="0.134792" ref="Mg"/>
+            <fraction n="0.002883" ref="Ca"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_CARBONATE">
+            <D value="2.958" unit="g/cm3"/>
+            <fraction n="0.288268" ref="Mg"/>
+            <fraction n="0.142453" ref="C"/>
+            <fraction n="0.569279" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_FLUORIDE">
+            <D value="3.0" unit="g/cm3"/>
+            <fraction n="0.390117" ref="Mg"/>
+            <fraction n="0.609883" ref="F"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_OXIDE">
+            <D value="3.58" unit="g/cm3"/>
+            <fraction n="0.603036" ref="Mg"/>
+            <fraction n="0.396964" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MAGNESIUM_TETRABORATE">
+            <D value="2.53" unit="g/cm3"/>
+            <fraction n="0.13537" ref="Mg"/>
+            <fraction n="0.240854" ref="B"/>
+            <fraction n="0.623776" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MERCURIC_IODIDE">
+            <D value="6.36" unit="g/cm3"/>
+            <fraction n="0.441452" ref="Hg"/>
+            <fraction n="0.558548" ref="I"/>
+        </material>
+        <material state="gas" name="G4_METHANE">
+            <D value="0.667151" unit="kg/m3"/>
+            <fraction n="0.748682" ref="C"/>
+            <fraction n="0.251318" ref="H"/>
+        </material>
+        <material state="solid" name="G4_METHANOL">
+            <D value="0.7914" unit="g/cm3"/>
+            <fraction n="0.374845" ref="C"/>
+            <fraction n="0.125828" ref="H"/>
+            <fraction n="0.499327" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MIX_D_WAX">
+            <D value="0.99" unit="g/cm3"/>
+            <fraction n="0.13404" ref="H"/>
+            <fraction n="0.77796" ref="C"/>
+            <fraction n="0.03502" ref="O"/>
+            <fraction n="0.038594" ref="Mg"/>
+            <fraction n="0.014386" ref="Ti"/>
+        </material>
+        <material state="solid" name="G4_MS20_TISSUE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.081192" ref="H"/>
+            <fraction n="0.583442" ref="C"/>
+            <fraction n="0.017798" ref="N"/>
+            <fraction n="0.186381" ref="O"/>
+            <fraction n="0.130287" ref="Mg"/>
+            <fraction n="9.0E-4" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_SKELETAL_ICRP">
+            <D value="1.05" unit="g/cm3"/>
+            <fraction n="0.102" ref="H"/>
+            <fraction n="0.143" ref="C"/>
+            <fraction n="0.034" ref="N"/>
+            <fraction n="0.71" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.002" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.001" ref="Cl"/>
+            <fraction n="0.004" ref="K"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_STRIATED_ICRU">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.102102" ref="H"/>
+            <fraction n="0.123123" ref="C"/>
+            <fraction n="0.035035" ref="N"/>
+            <fraction n="0.72973" ref="O"/>
+            <fraction n="0.001001" ref="Na"/>
+            <fraction n="0.002002" ref="P"/>
+            <fraction n="0.004004" ref="S"/>
+            <fraction n="0.003003" ref="K"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_WITH_SUCROSE">
+            <D value="1.11" unit="g/cm3"/>
+            <fraction n="0.098234" ref="H"/>
+            <fraction n="0.156214" ref="C"/>
+            <fraction n="0.035451" ref="N"/>
+            <fraction n="0.710101" ref="O"/>
+        </material>
+        <material state="solid" name="G4_MUSCLE_WITHOUT_SUCROSE">
+            <D value="1.07" unit="g/cm3"/>
+            <fraction n="0.101969" ref="H"/>
+            <fraction n="0.120058" ref="C"/>
+            <fraction n="0.035451" ref="N"/>
+            <fraction n="0.742522" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NAPHTHALENE">
+            <D value="1.145" unit="g/cm3"/>
+            <fraction n="0.937088" ref="C"/>
+            <fraction n="0.062912" ref="H"/>
+        </material>
+        <material state="solid" name="G4_NITROBENZENE">
+            <D value="1.19867" unit="g/cm3"/>
+            <fraction n="0.585368" ref="C"/>
+            <fraction n="0.040937" ref="H"/>
+            <fraction n="0.113775" ref="N"/>
+            <fraction n="0.259921" ref="O"/>
+        </material>
+        <material state="gas" name="G4_NITROUS_OXIDE">
+            <D value="1.83094" unit="kg/m3"/>
+            <fraction n="0.636484" ref="N"/>
+            <fraction n="0.363516" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-8062">
+            <D value="1.08" unit="g/cm3"/>
+            <fraction n="0.103509" ref="H"/>
+            <fraction n="0.648416" ref="C"/>
+            <fraction n="0.099536" ref="N"/>
+            <fraction n="0.148539" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-6-6">
+            <D value="1.14" unit="g/cm3"/>
+            <fraction n="0.636848" ref="C"/>
+            <fraction n="0.097981" ref="H"/>
+            <fraction n="0.123781" ref="N"/>
+            <fraction n="0.14139" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-6-10">
+            <D value="1.14" unit="g/cm3"/>
+            <fraction n="0.107062" ref="H"/>
+            <fraction n="0.680449" ref="C"/>
+            <fraction n="0.099189" ref="N"/>
+            <fraction n="0.1133" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NYLON-11_RILSAN">
+            <D value="1.425" unit="g/cm3"/>
+            <fraction n="0.115476" ref="H"/>
+            <fraction n="0.720818" ref="C"/>
+            <fraction n="0.076417" ref="N"/>
+            <fraction n="0.087289" ref="O"/>
+        </material>
+        <material state="solid" name="G4_OCTANE">
+            <D value="0.7026" unit="g/cm3"/>
+            <fraction n="0.84117" ref="C"/>
+            <fraction n="0.15883" ref="H"/>
+        </material>
+        <material state="solid" name="G4_PARAFFIN">
+            <D value="0.93" unit="g/cm3"/>
+            <fraction n="0.851387" ref="C"/>
+            <fraction n="0.148613" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-PENTANE">
+            <D value="0.6262" unit="g/cm3"/>
+            <fraction n="0.832357" ref="C"/>
+            <fraction n="0.167643" ref="H"/>
+        </material>
+        <material state="solid" name="G4_PHOTO_EMULSION">
+            <D value="3.815" unit="g/cm3"/>
+            <fraction n="0.0141" ref="H"/>
+            <fraction n="0.072261" ref="C"/>
+            <fraction n="0.01932" ref="N"/>
+            <fraction n="0.066101" ref="O"/>
+            <fraction n="0.00189" ref="S"/>
+            <fraction n="0.349103" ref="Br"/>
+            <fraction n="0.474105" ref="Ag"/>
+            <fraction n="0.00312" ref="I"/>
+        </material>
+        <material state="solid" name="G4_PLASTIC_SC_VINYLTOLUENE">
+            <D value="1.032" unit="g/cm3"/>
+            <fraction n="0.914709" ref="C"/>
+            <fraction n="0.085291" ref="H"/>
+        </material>
+        <material state="solid" name="G4_PLUTONIUM_DIOXIDE">
+            <D value="11.46" unit="g/cm3"/>
+            <fraction n="0.884089" ref="Pu"/>
+            <fraction n="0.115911" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYACRYLONITRILE">
+            <D value="1.17" unit="g/cm3"/>
+            <fraction n="0.679048" ref="C"/>
+            <fraction n="0.056986" ref="H"/>
+            <fraction n="0.263966" ref="N"/>
+        </material>
+        <material state="solid" name="G4_POLYCARBONATE">
+            <D value="1.2" unit="g/cm3"/>
+            <fraction n="0.755745" ref="C"/>
+            <fraction n="0.055494" ref="H"/>
+            <fraction n="0.18876" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYCHLOROSTYRENE">
+            <D value="1.3" unit="g/cm3"/>
+            <fraction n="0.69329" ref="C"/>
+            <fraction n="0.050908" ref="H"/>
+            <fraction n="0.255802" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYETHYLENE">
+            <D value="0.94" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_MYLAR">
+            <D value="1.4" unit="g/cm3"/>
+            <fraction n="0.625011" ref="C"/>
+            <fraction n="0.041961" ref="H"/>
+            <fraction n="0.333028" ref="O"/>
+        </material>
+        <material state="solid" name="G4_PLEXIGLASS">
+            <D value="1.19" unit="g/cm3"/>
+            <fraction n="0.599841" ref="C"/>
+            <fraction n="0.080542" ref="H"/>
+            <fraction n="0.319617" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYOXYMETHYLENE">
+            <D value="1.425" unit="g/cm3"/>
+            <fraction n="0.400011" ref="C"/>
+            <fraction n="0.067138" ref="H"/>
+            <fraction n="0.532851" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYPROPYLENE">
+            <D value="0.9" unit="g/cm3"/>
+            <fraction n="0.856282" ref="C"/>
+            <fraction n="0.143718" ref="H"/>
+        </material>
+        <material state="solid" name="G4_POLYSTYRENE">
+            <D value="1.06" unit="g/cm3"/>
+            <fraction n="0.922577" ref="C"/>
+            <fraction n="0.077423" ref="H"/>
+        </material>
+        <material state="solid" name="G4_TEFLON">
+            <D value="2.2" unit="g/cm3"/>
+            <fraction n="0.240179" ref="C"/>
+            <fraction n="0.759821" ref="F"/>
+        </material>
+        <material state="solid" name="G4_POLYTRIFLUOROCHLOROETHYLENE">
+            <D value="2.1" unit="g/cm3"/>
+            <fraction n="0.206247" ref="C"/>
+            <fraction n="0.489358" ref="F"/>
+            <fraction n="0.304394" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_ACETATE">
+            <D value="1.19" unit="g/cm3"/>
+            <fraction n="0.558059" ref="C"/>
+            <fraction n="0.070248" ref="H"/>
+            <fraction n="0.371693" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_ALCOHOL">
+            <D value="1.3" unit="g/cm3"/>
+            <fraction n="0.54529" ref="C"/>
+            <fraction n="0.091522" ref="H"/>
+            <fraction n="0.363188" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_BUTYRAL">
+            <D value="1.12" unit="g/cm3"/>
+            <fraction n="0.675729" ref="C"/>
+            <fraction n="0.099238" ref="H"/>
+            <fraction n="0.225033" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_CHLORIDE">
+            <D value="1.3" unit="g/cm3"/>
+            <fraction n="0.384357" ref="C"/>
+            <fraction n="0.048383" ref="H"/>
+            <fraction n="0.567261" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYLIDENE_CHLORIDE">
+            <D value="1.7" unit="g/cm3"/>
+            <fraction n="0.247791" ref="C"/>
+            <fraction n="0.020795" ref="H"/>
+            <fraction n="0.731414" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYLIDENE_FLUORIDE">
+            <D value="1.76" unit="g/cm3"/>
+            <fraction n="0.375135" ref="C"/>
+            <fraction n="0.031481" ref="H"/>
+            <fraction n="0.593383" ref="F"/>
+        </material>
+        <material state="solid" name="G4_POLYVINYL_PYRROLIDONE">
+            <D value="1.25" unit="g/cm3"/>
+            <fraction n="0.648399" ref="C"/>
+            <fraction n="0.08162" ref="H"/>
+            <fraction n="0.126026" ref="N"/>
+            <fraction n="0.143954" ref="O"/>
+        </material>
+        <material state="solid" name="G4_POTASSIUM_IODIDE">
+            <D value="3.13" unit="g/cm3"/>
+            <fraction n="0.235529" ref="K"/>
+            <fraction n="0.764471" ref="I"/>
+        </material>
+        <material state="solid" name="G4_POTASSIUM_OXIDE">
+            <D value="2.32" unit="g/cm3"/>
+            <fraction n="0.830148" ref="K"/>
+            <fraction n="0.169852" ref="O"/>
+        </material>
+        <material state="gas" name="G4_PROPANE">
+            <D value="1.87939" unit="kg/m3"/>
+            <fraction n="0.817136" ref="C"/>
+            <fraction n="0.182864" ref="H"/>
+        </material>
+        <material state="solid" name="G4_lPROPANE">
+            <D value="0.43" unit="g/cm3"/>
+            <fraction n="0.817136" ref="C"/>
+            <fraction n="0.182864" ref="H"/>
+        </material>
+        <material state="solid" name="G4_N-PROPYL_ALCOHOL">
+            <D value="0.8035" unit="g/cm3"/>
+            <fraction n="0.599586" ref="C"/>
+            <fraction n="0.134179" ref="H"/>
+            <fraction n="0.266234" ref="O"/>
+        </material>
+        <material state="solid" name="G4_PYRIDINE">
+            <D value="0.9819" unit="g/cm3"/>
+            <fraction n="0.759211" ref="C"/>
+            <fraction n="0.063713" ref="H"/>
+            <fraction n="0.177076" ref="N"/>
+        </material>
+        <material state="solid" name="G4_RUBBER_BUTYL">
+            <D value="0.92" unit="g/cm3"/>
+            <fraction n="0.143711" ref="H"/>
+            <fraction n="0.856289" ref="C"/>
+        </material>
+        <material state="solid" name="G4_RUBBER_NATURAL">
+            <D value="0.92" unit="g/cm3"/>
+            <fraction n="0.118371" ref="H"/>
+            <fraction n="0.881629" ref="C"/>
+        </material>
+        <material state="solid" name="G4_RUBBER_NEOPRENE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.05692" ref="H"/>
+            <fraction n="0.542646" ref="C"/>
+            <fraction n="0.400434" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_SILICON_DIOXIDE">
+            <D value="2.32" unit="g/cm3"/>
+            <fraction n="0.467434" ref="Si"/>
+            <fraction n="0.532566" ref="O"/>
+        </material>
+        <material state="solid" name="G4_SILVER_BROMIDE">
+            <D value="6.473" unit="g/cm3"/>
+            <fraction n="0.574465" ref="Ag"/>
+            <fraction n="0.425535" ref="Br"/>
+        </material>
+        <material state="solid" name="G4_SILVER_CHLORIDE">
+            <D value="5.56" unit="g/cm3"/>
+            <fraction n="0.752635" ref="Ag"/>
+            <fraction n="0.247365" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_SILVER_HALIDES">
+            <D value="6.47" unit="g/cm3"/>
+            <fraction n="0.422895" ref="Br"/>
+            <fraction n="0.573748" ref="Ag"/>
+            <fraction n="0.003357" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SILVER_IODIDE">
+            <D value="6.01" unit="g/cm3"/>
+            <fraction n="0.459459" ref="Ag"/>
+            <fraction n="0.540541" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SKIN_ICRP">
+            <D value="1.09" unit="g/cm3"/>
+            <fraction n="0.1" ref="H"/>
+            <fraction n="0.204" ref="C"/>
+            <fraction n="0.042" ref="N"/>
+            <fraction n="0.645" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.003" ref="Cl"/>
+            <fraction n="0.001" ref="K"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_CARBONATE">
+            <D value="2.532" unit="g/cm3"/>
+            <fraction n="0.433817" ref="Na"/>
+            <fraction n="0.113321" ref="C"/>
+            <fraction n="0.452862" ref="O"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_IODIDE">
+            <D value="3.667" unit="g/cm3"/>
+            <fraction n="0.153374" ref="Na"/>
+            <fraction n="0.846626" ref="I"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_MONOXIDE">
+            <D value="2.27" unit="g/cm3"/>
+            <fraction n="0.741858" ref="Na"/>
+            <fraction n="0.258142" ref="O"/>
+        </material>
+        <material state="solid" name="G4_SODIUM_NITRATE">
+            <D value="2.261" unit="g/cm3"/>
+            <fraction n="0.270485" ref="Na"/>
+            <fraction n="0.164796" ref="N"/>
+            <fraction n="0.564719" ref="O"/>
+        </material>
+        <material state="solid" name="G4_STILBENE">
+            <D value="0.9707" unit="g/cm3"/>
+            <fraction n="0.932896" ref="C"/>
+            <fraction n="0.067104" ref="H"/>
+        </material>
+        <material state="solid" name="G4_SUCROSE">
+            <D value="1.5805" unit="g/cm3"/>
+            <fraction n="0.421064" ref="C"/>
+            <fraction n="0.064782" ref="H"/>
+            <fraction n="0.514154" ref="O"/>
+        </material>
+        <material state="solid" name="G4_TERPHENYL">
+            <D value="1.24" unit="g/cm3"/>
+            <fraction n="0.938728" ref="C"/>
+            <fraction n="0.061272" ref="H"/>
+        </material>
+        <material state="solid" name="G4_TESTIS_ICRP">
+            <D value="1.04" unit="g/cm3"/>
+            <fraction n="0.106" ref="H"/>
+            <fraction n="0.099" ref="C"/>
+            <fraction n="0.02" ref="N"/>
+            <fraction n="0.766" ref="O"/>
+            <fraction n="0.002" ref="Na"/>
+            <fraction n="0.001" ref="P"/>
+            <fraction n="0.002" ref="S"/>
+            <fraction n="0.002" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_TETRACHLOROETHYLENE">
+            <D value="1.625" unit="g/cm3"/>
+            <fraction n="0.144854" ref="C"/>
+            <fraction n="0.855146" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_THALLIUM_CHLORIDE">
+            <D value="7.004" unit="g/cm3"/>
+            <fraction n="0.85218" ref="Tl"/>
+            <fraction n="0.14782" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_TISSUE_SOFT_ICRP">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.105" ref="H"/>
+            <fraction n="0.256" ref="C"/>
+            <fraction n="0.027" ref="N"/>
+            <fraction n="0.602" ref="O"/>
+            <fraction n="0.001" ref="Na"/>
+            <fraction n="0.002" ref="P"/>
+            <fraction n="0.003" ref="S"/>
+            <fraction n="0.002" ref="Cl"/>
+            <fraction n="0.002" ref="K"/>
+        </material>
+        <material state="solid" name="G4_TISSUE_SOFT_ICRU-4">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.101" ref="H"/>
+            <fraction n="0.111" ref="C"/>
+            <fraction n="0.026" ref="N"/>
+            <fraction n="0.762" ref="O"/>
+        </material>
+        <material state="gas" name="G4_TISSUE-METHANE">
+            <D value="1.06409" unit="kg/m3"/>
+            <fraction n="0.101869" ref="H"/>
+            <fraction n="0.456179" ref="C"/>
+            <fraction n="0.035172" ref="N"/>
+            <fraction n="0.40678" ref="O"/>
+        </material>
+        <material state="gas" name="G4_TISSUE-PROPANE">
+            <D value="1.82628" unit="kg/m3"/>
+            <fraction n="0.102672" ref="H"/>
+            <fraction n="0.56894" ref="C"/>
+            <fraction n="0.035022" ref="N"/>
+            <fraction n="0.293366" ref="O"/>
+        </material>
+        <material state="solid" name="G4_TITANIUM_DIOXIDE">
+            <D value="4.26" unit="g/cm3"/>
+            <fraction n="0.599342" ref="Ti"/>
+            <fraction n="0.400658" ref="O"/>
+        </material>
+        <material state="solid" name="G4_TOLUENE">
+            <D value="0.8669" unit="g/cm3"/>
+            <fraction n="0.912485" ref="C"/>
+            <fraction n="0.087515" ref="H"/>
+        </material>
+        <material state="solid" name="G4_TRICHLOROETHYLENE">
+            <D value="1.46" unit="g/cm3"/>
+            <fraction n="0.18283" ref="C"/>
+            <fraction n="0.007672" ref="H"/>
+            <fraction n="0.809499" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_TRIETHYL_PHOSPHATE">
+            <D value="1.07" unit="g/cm3"/>
+            <fraction n="0.395622" ref="C"/>
+            <fraction n="0.083001" ref="H"/>
+            <fraction n="0.351336" ref="O"/>
+            <fraction n="0.170041" ref="P"/>
+        </material>
+        <material state="solid" name="G4_TUNGSTEN_HEXAFLUORIDE">
+            <D value="2.4" unit="g/cm3"/>
+            <fraction n="0.617266" ref="W"/>
+            <fraction n="0.382734" ref="F"/>
+        </material>
+        <material state="solid" name="G4_URANIUM_DICARBIDE">
+            <D value="11.28" unit="g/cm3"/>
+            <fraction n="0.908333" ref="U"/>
+            <fraction n="0.091667" ref="C"/>
+        </material>
+        <material state="solid" name="G4_URANIUM_MONOCARBIDE">
+            <D value="13.63" unit="g/cm3"/>
+            <fraction n="0.951965" ref="U"/>
+            <fraction n="0.048035" ref="C"/>
+        </material>
+        <material state="solid" name="G4_URANIUM_OXIDE">
+            <D value="10.96" unit="g/cm3"/>
+            <fraction n="0.881498" ref="U"/>
+            <fraction n="0.118502" ref="O"/>
+        </material>
+        <material state="solid" name="G4_UREA">
+            <D value="1.323" unit="g/cm3"/>
+            <fraction n="0.199994" ref="C"/>
+            <fraction n="0.067134" ref="H"/>
+            <fraction n="0.466461" ref="N"/>
+            <fraction n="0.26641" ref="O"/>
+        </material>
+        <material state="solid" name="G4_VALINE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.512637" ref="C"/>
+            <fraction n="0.094645" ref="H"/>
+            <fraction n="0.119566" ref="N"/>
+            <fraction n="0.273152" ref="O"/>
+        </material>
+        <material state="solid" name="G4_VITON">
+            <D value="1.8" unit="g/cm3"/>
+            <fraction n="0.009417" ref="H"/>
+            <fraction n="0.280555" ref="C"/>
+            <fraction n="0.710028" ref="F"/>
+        </material>
+        <material state="gas" name="G4_WATER_VAPOR">
+            <D value="0.756182" unit="kg/m3"/>
+            <fraction n="0.111898" ref="H"/>
+            <fraction n="0.888102" ref="O"/>
+        </material>
+        <material state="solid" name="G4_XYLENE">
+            <D value="0.87" unit="g/cm3"/>
+            <fraction n="0.905059" ref="C"/>
+            <fraction n="0.094941" ref="H"/>
+        </material>
+        <material state="solid" name="G4_GRAPHITE">
+            <D value="2.21" unit="g/cm3"/>
+            <fraction n="1.0" ref="C"/>
+        </material>
+        <material state="liquid" name="G4_lH2">
+            <D value="0.0708" unit="g/cm3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="liquid" name="G4_lN2">
+            <D value="0.807" unit="g/cm3"/>
+            <fraction n="1.0" ref="N"/>
+        </material>
+        <material state="liquid" name="G4_lO2">
+            <D value="1.141" unit="g/cm3"/>
+            <fraction n="1.0" ref="O"/>
+        </material>
+        <material state="liquid" name="G4_lAr">
+            <D value="1.396" unit="g/cm3"/>
+            <fraction n="1.0" ref="Ar"/>
+        </material>
+        <material state="liquid" name="G4_lBr">
+            <D value="3.1028" unit="g/cm3"/>
+            <fraction n="1.0" ref="Br"/>
+        </material>
+        <material state="liquid" name="G4_lKr">
+            <D value="2.418" unit="g/cm3"/>
+            <fraction n="1.0" ref="Kr"/>
+        </material>
+        <material state="liquid" name="G4_lXe">
+            <D value="2.953" unit="g/cm3"/>
+            <fraction n="1.0" ref="Xe"/>
+        </material>
+        <material state="solid" name="G4_PbWO4">
+            <D value="8.28" unit="g/cm3"/>
+            <fraction n="0.140637" ref="O"/>
+            <fraction n="0.455366" ref="Pb"/>
+            <fraction n="0.403998" ref="W"/>
+        </material>
+        <material state="gas" name="G4_Galactic">
+            <D value="1.0E-22" unit="kg/m3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="solid" name="G4_GRAPHITE_POROUS">
+            <D value="1.7" unit="g/cm3"/>
+            <fraction n="1.0" ref="C"/>
+        </material>
+        <material state="solid" name="G4_LUCITE">
+            <D value="1.19" unit="g/cm3"/>
+            <fraction n="0.080538" ref="H"/>
+            <fraction n="0.599848" ref="C"/>
+            <fraction n="0.319614" ref="O"/>
+        </material>
+        <material state="solid" name="G4_BRASS">
+            <D value="8.52" unit="g/cm3"/>
+            <fraction n="0.57513" ref="Cu"/>
+            <fraction n="0.334122" ref="Zn"/>
+            <fraction n="0.090748" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_BRONZE">
+            <D value="8.82" unit="g/cm3"/>
+            <fraction n="0.849368" ref="Cu"/>
+            <fraction n="0.088391" ref="Zn"/>
+            <fraction n="0.062241" ref="Pb"/>
+        </material>
+        <material state="solid" name="G4_STAINLESS-STEEL">
+            <D value="8.0" unit="g/cm3"/>
+            <fraction n="0.746213" ref="Fe"/>
+            <fraction n="0.169001" ref="Cr"/>
+            <fraction n="0.084786" ref="Ni"/>
+        </material>
+        <material state="solid" name="G4_CR39">
+            <D value="1.32" unit="g/cm3"/>
+            <fraction n="0.066151" ref="H"/>
+            <fraction n="0.525505" ref="C"/>
+            <fraction n="0.408345" ref="O"/>
+        </material>
+        <material state="solid" name="G4_OCTADECANOL">
+            <D value="0.812" unit="g/cm3"/>
+            <fraction n="0.141599" ref="H"/>
+            <fraction n="0.799252" ref="C"/>
+            <fraction n="0.059149" ref="O"/>
+        </material>
+        <material state="solid" name="G4_KEVLAR">
+            <D value="1.44" unit="g/cm3"/>
+            <fraction n="0.705796" ref="C"/>
+            <fraction n="0.042307" ref="H"/>
+            <fraction n="0.134312" ref="O"/>
+            <fraction n="0.117584" ref="N"/>
+        </material>
+        <material state="solid" name="G4_DACRON">
+            <D value="1.4" unit="g/cm3"/>
+            <fraction n="0.625011" ref="C"/>
+            <fraction n="0.041961" ref="H"/>
+            <fraction n="0.333028" ref="O"/>
+        </material>
+        <material state="solid" name="G4_NEOPRENE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.542642" ref="C"/>
+            <fraction n="0.056923" ref="H"/>
+            <fraction n="0.400435" ref="Cl"/>
+        </material>
+        <material state="solid" name="G4_CYTOSINE">
+            <D value="1.55" unit="g/cm3"/>
+            <fraction n="0.045361" ref="H"/>
+            <fraction n="0.432421" ref="C"/>
+            <fraction n="0.378213" ref="N"/>
+            <fraction n="0.144006" ref="O"/>
+        </material>
+        <material state="solid" name="G4_THYMINE">
+            <D value="1.23" unit="g/cm3"/>
+            <fraction n="0.047954" ref="H"/>
+            <fraction n="0.476187" ref="C"/>
+            <fraction n="0.222129" ref="N"/>
+            <fraction n="0.25373" ref="O"/>
+        </material>
+        <material state="solid" name="G4_URACIL">
+            <D value="1.32" unit="g/cm3"/>
+            <fraction n="0.03597" ref="H"/>
+            <fraction n="0.428622" ref="C"/>
+            <fraction n="0.249927" ref="N"/>
+            <fraction n="0.285482" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DEOXYRIBOSE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.085324" ref="H"/>
+            <fraction n="0.508364" ref="C"/>
+            <fraction n="0.406312" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_DEOXYRIBOSE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.084896" ref="H"/>
+            <fraction n="0.722592" ref="C"/>
+            <fraction n="0.192512" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_PHOSPHATE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.326138" ref="P"/>
+            <fraction n="0.673862" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_ADENINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.030061" ref="H"/>
+            <fraction n="0.447763" ref="C"/>
+            <fraction n="0.522176" ref="N"/>
+        </material>
+        <material state="solid" name="G4_DNA_GUANINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.026857" ref="H"/>
+            <fraction n="0.400041" ref="C"/>
+            <fraction n="0.466523" ref="N"/>
+            <fraction n="0.106578" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_CYTOSINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.036621" ref="H"/>
+            <fraction n="0.43638" ref="C"/>
+            <fraction n="0.381675" ref="N"/>
+            <fraction n="0.145324" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_THYMINE">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.040284" ref="H"/>
+            <fraction n="0.480024" ref="C"/>
+            <fraction n="0.223919" ref="N"/>
+            <fraction n="0.255774" ref="O"/>
+        </material>
+        <material state="solid" name="G4_DNA_URACIL">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.027222" ref="H"/>
+            <fraction n="0.432511" ref="C"/>
+            <fraction n="0.252195" ref="N"/>
+            <fraction n="0.288072" ref="O"/>
+        </material>
+        <material state="gas" name="Isobutane">
+            <D value="2.51" unit="kg/m3"/>
+            <fraction n="0.826583" ref="C"/>
+            <fraction n="0.173417" ref="H"/>
+        </material>
+        <material state="gas" name="TMA">
+            <D value="627.0" unit="kg/m3"/>
+            <fraction n="0.609574" ref="C"/>
+            <fraction n="0.153466" ref="H"/>
+            <fraction n="0.236959" ref="N"/>
+        </material>
+        <material state="gas" name="GasMixture-Argon2%Isobutane1.4Bar">
+            <D value="2.319820104" unit="kg/m3"/>
+            <fraction n="0.98" ref="Ar"/>
+            <fraction n="0.016532" ref="C"/>
+            <fraction n="0.003468" ref="H"/>
+        </material>
+        <material state="gas" name="GasMixture-Xenon2%Isobutane1.4Bar">
+            <D value="7.496860518" unit="kg/m3"/>
+            <fraction n="0.98" ref="Xe"/>
+            <fraction n="0.016532" ref="C"/>
+            <fraction n="0.003468" ref="H"/>
+        </material>
+        <material state="gas" name="GasMixture-Neon2%Isobutane1.4Bar">
+            <D value="1.204745976" unit="kg/m3"/>
+            <fraction n="0.98" ref="Ne"/>
+            <fraction n="0.016532" ref="C"/>
+            <fraction n="0.003468" ref="H"/>
+        </material>
+        <material state="gas" name="GasMixture-Argon2%TMA1.4Bar">
+            <D value="19.57688401" unit="kg/m3"/>
+            <fraction n="0.98" ref="Ar"/>
+            <fraction n="0.012191" ref="C"/>
+            <fraction n="0.003069" ref="H"/>
+            <fraction n="0.004739" ref="N"/>
+        </material>
+        <material state="gas" name="GasMixture-Xenon2%TMA1.4Bar">
+            <D value="24.75392442" unit="kg/m3"/>
+            <fraction n="0.98" ref="Xe"/>
+            <fraction n="0.012191" ref="C"/>
+            <fraction n="0.003069" ref="H"/>
+            <fraction n="0.004739" ref="N"/>
+        </material>
+        <material state="gas" name="GasMixture-Neon2%TMA1.4Bar">
+            <D value="18.46180988" unit="kg/m3"/>
+            <fraction n="0.98" ref="Ne"/>
+            <fraction n="0.012191" ref="C"/>
+            <fraction n="0.003069" ref="H"/>
+            <fraction n="0.004739" ref="N"/>
+        </material>
+        <material state="gas" name="Vacuum">
+            <D value="1.0E-22" unit="kg/m3"/>
+            <fraction n="1.0" ref="H"/>
+        </material>
+        <material state="solid" name="BC408">
+            <D value="1.03" unit="g/cm3"/>
+            <fraction n="0.085" ref="H"/>
+            <fraction n="0.915" ref="C"/>
+        </material>
+        <material state="liquid" name="HC">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.077423" ref="H"/>
+            <fraction n="0.922577" ref="C"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+0%Pb">
+            <D value="1.0" unit="g/cm3"/>
+            <fraction n="0.077423" ref="H"/>
+            <fraction n="0.922577" ref="C"/>
+            <fraction n="0.0" ref="Pb"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+0%Pb+0.1%Cd">
+            <D value="1.00765" unit="g/cm3"/>
+            <fraction n="0.077345" ref="H"/>
+            <fraction n="0.921655" ref="C"/>
+            <fraction n="0.0" ref="Pb"/>
+            <fraction n="0.001" ref="Cd"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+1%Pb">
+            <D value="1.1035" unit="g/cm3"/>
+            <fraction n="0.076648" ref="H"/>
+            <fraction n="0.913352" ref="C"/>
+            <fraction n="0.01" ref="Pb"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+1%Pb+0.1%Cd">
+            <D value="1.11115" unit="g/cm3"/>
+            <fraction n="0.076571" ref="H"/>
+            <fraction n="0.912429" ref="C"/>
+            <fraction n="0.01" ref="Pb"/>
+            <fraction n="0.001" ref="Cd"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+5%Pb">
+            <D value="1.5175" unit="g/cm3"/>
+            <fraction n="0.073552" ref="H"/>
+            <fraction n="0.876448" ref="C"/>
+            <fraction n="0.05" ref="Pb"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+5%Pb+0.1%Cd">
+            <D value="1.52515" unit="g/cm3"/>
+            <fraction n="0.073474" ref="H"/>
+            <fraction n="0.875526" ref="C"/>
+            <fraction n="0.05" ref="Pb"/>
+            <fraction n="0.001" ref="Cd"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+10%Pb">
+            <D value="2.035" unit="g/cm3"/>
+            <fraction n="0.06968" ref="H"/>
+            <fraction n="0.83032" ref="C"/>
+            <fraction n="0.1" ref="Pb"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+10%Pb+0.1%Cd">
+            <D value="2.04265" unit="g/cm3"/>
+            <fraction n="0.069603" ref="H"/>
+            <fraction n="0.829397" ref="C"/>
+            <fraction n="0.1" ref="Pb"/>
+            <fraction n="0.001" ref="Cd"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+20%Pb">
+            <D value="3.07" unit="g/cm3"/>
+            <fraction n="0.061938" ref="H"/>
+            <fraction n="0.738062" ref="C"/>
+            <fraction n="0.2" ref="Pb"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+20%Pb+0.1%Cd">
+            <D value="3.07765" unit="g/cm3"/>
+            <fraction n="0.061861" ref="H"/>
+            <fraction n="0.737139" ref="C"/>
+            <fraction n="0.2" ref="Pb"/>
+            <fraction n="0.001" ref="Cd"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+50%Pb">
+            <D value="6.175" unit="g/cm3"/>
+            <fraction n="0.038711" ref="H"/>
+            <fraction n="0.461289" ref="C"/>
+            <fraction n="0.5" ref="Pb"/>
+        </material>
+        <material state="liquid" name="LiquidScintillator-HC+50%Pb+0.1%Cd">
+            <D value="6.18265" unit="g/cm3"/>
+            <fraction n="0.038634" ref="H"/>
+            <fraction n="0.460366" ref="C"/>
+            <fraction n="0.5" ref="Pb"/>
+            <fraction n="0.001" ref="Cd"/>
+        </material>
+    </materials>
+    <solids>
+        <box name="chamberBodyBaseSolid" x="134.0" y="134.0" z="30.0"/>
+        <tube name="chamberBodyHoleSolid" rmax="51.0" z="30.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction name="chamberBodySolid">
+            <first ref="chamberBodyBaseSolid"/>
+            <second ref="chamberBodyHoleSolid"/>
+        </subtraction>
+        <box name="chamberBackplateSolid" x="134.0" y="134.0" z="15.0"/>
+        <tube name="chamberTeflonWallSolid" rmax="51.0" z="30.0" rmin="50.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <box name="kaptonReadoutSolid" x="134.0" y="134.0" z="0.5"/>
+        <box name="copperReadoutSolid" x="60.0" y="60.0" z="0.2"/>
+        <tube name="cathodeTeflonDiskBaseSolid" rmax="67.0" z="5.0" rmin="15.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <tube name="cathodeCopperDiskSolid" rmax="45.0" z="1.0" rmin="8.5" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction name="cathodeTeflonDiskSolid">
+            <position name="cathodeTeflonDiskSolid.position" z="-2.0"/>
+            <first ref="cathodeTeflonDiskBaseSolid"/>
+            <second ref="cathodeCopperDiskSolid"/>
+        </subtraction>
+        <tube name="cathodeWindowSolid" rmax="15.0" z="0.004" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <box name="cathodePatternLineAux" x="0.3" y="17.0" z="1.0"/>
+        <tube name="cathodePatternCentralHole" rmax="4.25" z="1.1" rmin="0.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <subtraction name="cathodePatternLine">
+            <first ref="cathodePatternLineAux"/>
+            <second ref="cathodePatternCentralHole"/>
+        </subtraction>
+        <tube name="cathodePatternDisk" rmax="4.25" z="1.0" rmin="3.95" startphi="0.0" deltaphi="6.283185307179586"/>
+        <union name="cathodeCopperDiskSolidAux0">
+            <rotation name="cathodeCopperDiskSolidAux0.rotation" unit="deg"/>
+            <first ref="cathodeCopperDiskSolid"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union name="cathodeCopperDiskSolidAux1">
+            <rotation name="cathodeCopperDiskSolidAux1.rotation" z="45.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux0"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union name="cathodeCopperDiskSolidAux2">
+            <rotation name="cathodeCopperDiskSolidAux2.rotation" z="90.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux1"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union name="cathodeCopperDiskSolidAux3">
+            <rotation name="cathodeCopperDiskSolidAux3.rotation" z="135.0" unit="deg"/>
+            <first ref="cathodeCopperDiskSolidAux2"/>
+            <second ref="cathodePatternLine"/>
+        </union>
+        <union name="cathodeCopperDiskFinal.solid">
+            <first ref="cathodeCopperDiskSolidAux3"/>
+            <second ref="cathodePatternDisk"/>
+        </union>
+        <tube name="cathodeFillingBaseSolid" rmax="15.0" z="5.0" rmin="0.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <subtraction name="cathodeFillingSolid">
+            <position name="cathodeFillingSolid.position" z="-2.0"/>
+            <first ref="cathodeFillingBaseSolid"/>
+            <second ref="cathodeCopperDiskFinal.solid"/>
+        </subtraction>
+        <tube name="gasSolidOriginal" rmax="50.0" z="30.0" rmin="0.0" startphi="0.0" deltaphi="6.283185307179586"/>
+        <subtraction name="gasSolidAux">
+            <position name="gasSolidAux.position" z="-14.9"/>
+            <rotation name="gasSolidAux.rotation" z="45.0" unit="deg"/>
+            <first ref="gasSolidOriginal"/>
+            <second ref="copperReadoutSolid"/>
+        </subtraction>
+        <subtraction name="gasSolid">
+            <position name="gasSolid.position" z="14.998"/>
+            <first ref="gasSolidAux"/>
+            <second ref="cathodeWindowSolid"/>
+        </subtraction>
+        <tube name="detectorPipeChamberFlangeSolid" rmax="67.0" z="14.0" rmin="0.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <tube name="detectorPipeTelescopeFlangeSolid" rmax="75.0" z="18.0" rmin="0.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <tube name="detectorPipeSection1of2Solid" rmax="46.0" z="327.0" rmin="0.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <tube name="detectorPipeSection2of2Solid" rmax="54.0" z="132.0" rmin="0.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <union name="detectorPipeAux1">
+            <position name="detectorPipeAux1.position" z="170.5"/>
+            <first ref="detectorPipeChamberFlangeSolid"/>
+            <second ref="detectorPipeSection1of2Solid"/>
+        </union>
+        <union name="detectorPipeAux2">
+            <position name="detectorPipeAux2.position" z="400.0"/>
+            <first ref="detectorPipeAux1"/>
+            <second ref="detectorPipeSection2of2Solid"/>
+        </union>
+        <union name="detectorPipeNotEmpty">
+            <position name="detectorPipeNotEmpty.position" z="475.0"/>
+            <first ref="detectorPipeAux2"/>
+            <second ref="detectorPipeTelescopeFlangeSolid"/>
+        </union>
+        <tube name="detectorPipeInside1of3Solid" rmax="21.5" z="179.35" rmin="0.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <tube name="detectorPipeInside2of3Solid" rmax="34.0" z="160.28" rmin="0.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <tube name="detectorPipeInside3of3Solid" rmax="42.5" z="106.0" rmin="0.0" startphi="0.0"
+              deltaphi="6.283185307179586"/>
+        <cone name="detectorPipeInsideCone1of3Solid" z="21.65" rmax1="21.5" rmax2="34.0" deltaphi="6.283185307179586"/>
+        <cone name="detectorPipeInsideCone2of3Solid" z="14.72" rmax1="34.0" rmax2="42.5" deltaphi="6.283185307179586"/>
+        <cone name="detectorPipeInsideCone3of3Solid" z="9.0" rmax1="42.5" rmax2="54.0" deltaphi="6.283185307179586"/>
+        <union name="detectorPipeInsideAux1">
+            <position name="detectorPipeInsideAux1.position" z="100.5"/>
+            <first ref="detectorPipeInside1of3Solid"/>
+            <second ref="detectorPipeInsideCone1of3Solid"/>
+        </union>
+        <union name="detectorPipeInsideAux2">
+            <position name="detectorPipeInsideAux2.position" z="191.465"/>
+            <first ref="detectorPipeInsideAux1"/>
+            <second ref="detectorPipeInside2of3Solid"/>
+        </union>
+        <union name="detectorPipeInsideAux3">
+            <position name="detectorPipeInsideAux3.position" z="191.465"/>
+            <first ref="detectorPipeInsideAux2"/>
+            <second ref="detectorPipeInsideCone2of3Solid"/>
+        </union>
+        <union name="detectorPipeInsideAux4">
+            <position name="detectorPipeInsideAux4.position" z="251.82500000000002"/>
+            <first ref="detectorPipeInsideAux3"/>
+            <second ref="detectorPipeInside3of3Solid"/>
+        </union>
+        <union name="detectorPipeInside">
+            <position name="detectorPipeInside.position" z="309.32500000000005"/>
+            <first ref="detectorPipeInsideAux4"/>
+            <second ref="detectorPipeInsideCone3of3Solid"/>
+        </union>
+        <subtraction name="detectorPipeSolid">
+            <position name="detectorPipeSolid.position" z="82.675"/>
+            <first ref="detectorPipeNotEmpty"/>
+            <second ref="detectorPipeInside"/>
+        </subtraction>
+        <box name="leadBoxSolid" x="590.0" y="590.0" z="540.0"/>
+        <box name="leadBoxShaftSolid" x="194.0" y="170.0" z="340.0"/>
+        <subtraction name="leadBoxWithShaftSolid">
+            <position name="leadBoxWithShaftSolid.position" z="100.0"/>
+            <first ref="leadBoxSolid"/>
+            <second ref="leadBoxShaftSolid"/>
+        </subtraction>
+        <box name="worldBox" x="2000.0" y="2000.0" z="2000.0"/>
+    </solids>
+    <structure>
+        <volume name="chamberBodyVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="chamberBodySolid"/>
+        </volume>
+        <volume name="chamberBackplateVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="chamberBackplateSolid"/>
+        </volume>
+        <volume name="chamberTeflonWallVolume">
+            <materialref ref="G4_TEFLON"/>
+            <solidref ref="chamberTeflonWallSolid"/>
+        </volume>
+        <volume name="kaptonReadoutVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="kaptonReadoutSolid"/>
+        </volume>
+        <volume name="copperReadoutVolume">
+            <materialref ref="G4_KAPTON"/>
+            <solidref ref="copperReadoutSolid"/>
+        </volume>
+        <volume name="cathodeTeflonDiskVolume">
+            <materialref ref="G4_TEFLON"/>
+            <solidref ref="cathodeTeflonDiskSolid"/>
+        </volume>
+        <volume name="cathodeWindowVolume">
+            <materialref ref="G4_MYLAR"/>
+            <solidref ref="cathodeWindowSolid"/>
+        </volume>
+        <volume name="cathodeCopperDiskFinal">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="cathodeCopperDiskFinal.solid"/>
+        </volume>
+        <volume name="cathodeFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="cathodeFillingSolid"/>
+        </volume>
+        <volume name="gasVolume">
+            <materialref ref="G4_Ar"/>
+            <solidref ref="gasSolid"/>
+        </volume>
+        <assembly name="Chamber">
+            <physvol name="gas">
+                <volumeref ref="gasVolume"/>
+            </physvol>
+            <physvol name="chamberBackplate">
+                <volumeref ref="chamberBackplateVolume"/>
+                <position name="chamberBackplate.position" z="-23.0"/>
+            </physvol>
+            <physvol name="chamberBody">
+                <volumeref ref="chamberBodyVolume"/>
+            </physvol>
+            <physvol name="chamberTeflonWall">
+                <volumeref ref="chamberTeflonWallVolume"/>
+            </physvol>
+            <physvol name="kaptonReadout">
+                <volumeref ref="kaptonReadoutVolume"/>
+                <position name="kaptonReadout.position" z="-15.25"/>
+            </physvol>
+            <physvol name="copperReadout">
+                <volumeref ref="copperReadoutVolume"/>
+                <position name="copperReadout.position" z="-14.9"/>
+                <rotation name="copperReadout.rotation" z="45.0" unit="deg"/>
+            </physvol>
+            <physvol name="cathodeWindow">
+                <volumeref ref="cathodeWindowVolume"/>
+                <position name="cathodeWindow.position" z="14.998"/>
+            </physvol>
+            <physvol name="cathodeTeflonDisk">
+                <volumeref ref="cathodeTeflonDiskVolume"/>
+                <position name="cathodeTeflonDisk.position" z="17.5"/>
+            </physvol>
+            <physvol name="cathodeFilling">
+                <volumeref ref="cathodeFillingVolume"/>
+                <position name="cathodeFilling.position" z="17.5"/>
+            </physvol>
+            <physvol name="cathodeCopperDiskPattern">
+                <volumeref ref="cathodeCopperDiskFinal"/>
+                <position name="cathodeCopperDiskPattern.position" z="15.5"/>
+            </physvol>
+        </assembly>
+        <volume name="detectorPipeVolume">
+            <materialref ref="G4_Cu"/>
+            <solidref ref="detectorPipeSolid"/>
+        </volume>
+        <volume name="detectorPipeFillingVolume">
+            <materialref ref="G4_Galactic"/>
+            <solidref ref="detectorPipeInside"/>
+        </volume>
+        <assembly name="DetectorPipe">
+            <physvol name="detectorPipe">
+                <volumeref ref="detectorPipeVolume"/>
+            </physvol>
+            <physvol name="detectorPipeFilling">
+                <volumeref ref="detectorPipeFillingVolume"/>
+                <position name="detectorPipeFilling.position" z="82.675"/>
+            </physvol>
+        </assembly>
+        <volume name="ShieldingVolume">
+            <materialref ref="G4_Pb"/>
+            <solidref ref="leadBoxWithShaftSolid"/>
+        </volume>
+        <assembly name="Shielding">
+            <physvol name="shielding20cm">
+                <volumeref ref="ShieldingVolume"/>
+                <position name="shielding20cm.position" z="29.5"/>
+            </physvol>
+        </assembly>
+        <volume name="world">
+            <physvol name="Chamber">
+                <volumeref ref="Chamber"/>
+            </physvol>
+            <physvol name="DetectorPipe">
+                <volumeref ref="DetectorPipe"/>
+                <position name="DetectorPipe.position" z="27.0"/>
+            </physvol>
+            <physvol name="Shielding">
+                <volumeref ref="Shielding"/>
+            </physvol>
+            <materialref ref="G4_AIR"/>
+            <solidref ref="worldBox"/>
+        </volume>
+    </structure>
+    <setup name="Default" version="1.0">
+        <world ref="world"/>
+    </setup>
+</gdml>

--- a/src/EventAction.cxx
+++ b/src/EventAction.cxx
@@ -27,11 +27,13 @@ void EventAction::BeginOfEventAction(const G4Event* geant4_event) {
 
     if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
         cout << "DEBUG: Start of event ID " << event_number << " (" << event_number + 1 << " of "
-             << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored." << endl;
+             << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored."
+             << endl;
     } else if ((restG4Metadata->PrintProgress() || restG4Metadata->GetVerboseLevel() >= REST_Info) &&
                geant4_event->GetEventID() % 10000 == 0) {
         cout << "INFO: Start of event ID " << event_number << " (" << event_number + 1 << " of "
-             << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored." << endl
+             << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored."
+             << endl
              << endl;
     }
 
@@ -47,7 +49,8 @@ void EventAction::BeginOfEventAction(const G4Event* geant4_event) {
     for (int i = 0; i < restG4Metadata->GetNumberOfActiveVolumes(); i++) {
         Double_t rndNumber = G4UniformRand();
 
-        if (restG4Metadata->GetStorageChance(i) >= rndNumber)
+        if (restG4Metadata->GetStorageChance(restG4Metadata->GetGeometry()->GetActiveVolumeFromIndex(i)) >=
+            rndNumber)
             restG4Event->ActivateVolumeForStorage(i);
         else
             restG4Event->DisableVolumeForStorage(i);


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![3751](https://badgen.net/badge/Size/3751/orange) [![](https://gitlab.cern.ch/rest-for-physics/restg4/badges/dev-lobis-geometry/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restg4/-/commits/dev-lobis-geometry)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Mostly the same as https://github.com/rest-for-physics/geant4lib/pull/34