### PR TITLE
Change directory

### DIFF
--- a/restG4.cxx
+++ b/restG4.cxx
@@ -67,9 +67,14 @@ int main(int argc, char** argv) {
     CommandLineParameters commandLineParameters = CommandLineSetup::ProcessParameters(argc, argv);
     CommandLineSetup::Print(commandLineParameters);
 
+    /// Separating relative path and pure RML filename
     char* inputConfigFile = const_cast<char*>(commandLineParameters.rmlFile.Data());
+    std::pair<string, string> pathAndRml = TRestTools::SeparatePathAndName(inputConfigFile);
+    char* inputRMLClean = (char*)pathAndRml.second.data();
 
-    restG4Metadata = new TRestGeant4Metadata(inputConfigFile);
+    TRestTools::ChangeDirectory(pathAndRml.first);
+
+    restG4Metadata = new TRestGeant4Metadata(inputRMLClean);
 
     string geant4Version = TRestTools::Execute("geant4-config --version");
     restG4Metadata->SetGeant4Version(geant4Version);
@@ -92,10 +97,13 @@ int main(int argc, char** argv) {
     restG4Metadata->Set_GDML_Reference(gdml->GetGDMLVersion());
     restG4Metadata->SetMaterialsReference(gdml->GetEntityVersion("materials"));
 
-    restPhysList = new TRestGeant4PhysicsLists(inputConfigFile);
+    restPhysList = new TRestGeant4PhysicsLists(inputRMLClean);
 
     restRun = new TRestRun();
-    restRun->LoadConfigFromFile(inputConfigFile);
+    restRun->LoadConfigFromFile(inputRMLClean);
+
+    TRestTools::ReturnToPreviousDirectory();
+
     TString runTag = restRun->GetRunTag();
     if (runTag == "Null" || runTag == "") restRun->SetRunTag(restG4Metadata->GetTitle());
 

--- a/src/CommandLineSetup.cxx
+++ b/src/CommandLineSetup.cxx
@@ -4,6 +4,7 @@
 
 #include "CommandLineSetup.h"
 
+#include <unistd.h>
 #include <iostream>
 
 using namespace std;

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -35,6 +35,7 @@
 #include <G4UAtomicDeexcitation.hh>
 #include <G4UnitsTable.hh>
 #include <G4UniversalFluctuation.hh>
+#include <G4IonTable.hh>
 
 #include "Particles.h"
 


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![13](https://badgen.net/badge/Size/13/orange) [![](https://gitlab.cern.ch/rest-for-physics/restg4/badges/change_directory/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restg4/-/commits/change_directory)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR will change the directory to the location where RML files are found before loading TRestGeant4Metadata and other classes.

This allows now for example to execute the examples as:

```
cd source/packages/restG4
restG4 examples/01.NLDBD/NLDBD.rml
```