### PR TITLE
implemented additional options to command line parameters

### DIFF
--- a/restG4.cxx
+++ b/restG4.cxx
@@ -95,8 +95,6 @@ int main(int argc, char** argv) {
     auto gdml = new TRestGDMLParser();
 
     // This call will generate a new single file GDML output
-    auto geometryFilename = restG4Metadata->Get_GDML_Filename();
-    cout << "Geometry Filename: " << geometryFilename << endl;
     gdml->Load((string)restG4Metadata->Get_GDML_Filename());
 
     // We redefine the value of the GDML file to be used in DetectorConstructor.

--- a/restG4.cxx
+++ b/restG4.cxx
@@ -64,6 +64,9 @@ Int_t N_events;
 int main(int argc, char** argv) {
     auto start_time = chrono::steady_clock::now();
 
+    char cwd[kMAXPATHLEN];
+    cout << "Current working directory: " << getcwd(cwd, sizeof(cwd)) << endl;
+
     CommandLineParameters commandLineParameters = CommandLineSetup::ProcessParameters(argc, argv);
     CommandLineSetup::Print(commandLineParameters);
 
@@ -75,6 +78,10 @@ int main(int argc, char** argv) {
     TRestTools::ChangeDirectory(pathAndRml.first);
 
     restG4Metadata = new TRestGeant4Metadata(inputRMLClean);
+
+    if (!commandLineParameters.geometryFile.IsNull()) {
+        restG4Metadata->Set_GDML_Filename(commandLineParameters.geometryFile.Data());
+    }
 
     string geant4Version = TRestTools::Execute("geant4-config --version");
     restG4Metadata->SetGeant4Version(geant4Version);
@@ -88,6 +95,8 @@ int main(int argc, char** argv) {
     auto gdml = new TRestGDMLParser();
 
     // This call will generate a new single file GDML output
+    auto geometryFilename = restG4Metadata->Get_GDML_Filename();
+    cout << "Geometry Filename: " << geometryFilename << endl;
     gdml->Load((string)restG4Metadata->Get_GDML_Filename());
 
     // We redefine the value of the GDML file to be used in DetectorConstructor.
@@ -101,6 +110,10 @@ int main(int argc, char** argv) {
 
     restRun = new TRestRun();
     restRun->LoadConfigFromFile(inputRMLClean);
+
+    if (!commandLineParameters.outputFile.IsNull()) {
+        restRun->SetOutputFileName(commandLineParameters.outputFile.Data());
+    }
 
     TRestTools::ReturnToPreviousDirectory();
 

--- a/src/CommandLineSetup.cxx
+++ b/src/CommandLineSetup.cxx
@@ -6,18 +6,20 @@
 
 #include <getopt.h>
 #include <unistd.h>
+
 #include <iostream>
 
 using namespace std;
 
 void CommandLineSetup::ShowUsage() {
-    cout << "restG4 requires at least one parameter, the rml configuration file (-c is optional)" << endl
+    cout << "restG4 requires at least one parameter, the rml configuration file" << endl
          << endl
          << "example: restG4 example.rml" << endl
          << endl
          << "there are other convenient optional parameters that override the ones in the rml file:" << endl
          << "\t-h or --help | show usage (this text)" << endl
          << "\t-c example.rml | specify RML file (same as calling restG4 example.rml)" << endl
+         << "\t-o output.root | specify output file" << endl
          << "\t-g geometry.gdml | specify geometry file" << endl
          << "\t-i | set interactive mode (default=false)" << endl
          << "\t-s | set serial mode (no multithreading) (default=true)" << endl
@@ -30,7 +32,7 @@ CommandLineParameters CommandLineSetup::ProcessParameters(int argc, char** argv)
     if (argc >= 2) {
         // presumably invoked as `restG4 example.rml` or `restG4 --help`
         TString argument = argv[1];
-        if (argument.EqualTo("--help") | argument.EqualTo("-h")) {
+        if (argument.EqualTo("--help") || argument.EqualTo("-h")) {
             ShowUsage();
             exit(0);
         } else {
@@ -81,9 +83,7 @@ CommandLineParameters CommandLineSetup::ProcessParameters(int argc, char** argv)
             case 'g':
                 if (!parameters.geometryFile.IsNull()) {
                     cout << "CommandLineParameters::ProcessParameters - Cannot specify multiple geometry "
-                            "files "
-                            "via the -g flag. "
-                            "Please use at most one"
+                            "files via the -g flag. Please use at most one"
                          << endl;
                     exit(1);
                 }
@@ -105,9 +105,13 @@ CommandLineParameters CommandLineSetup::ProcessParameters(int argc, char** argv)
 
     return parameters;
 }
+
 void CommandLineSetup::Print(const CommandLineParameters& parameters) {
     cout << "Command line parameters configuration:" << endl
          << "\t- RML file: " << parameters.rmlFile << endl
+         << (!parameters.outputFile.IsNull() ? "\t- Output file: " + parameters.outputFile + "\n" : "")
+         << (!parameters.geometryFile.IsNull() ? "\t- Geometry file: " + parameters.geometryFile + "\n" : "")
+         << (parameters.interactive ? "\t- Interactive: True\n" : "")  //
          << "\t- Execution mode: "
          << (parameters.serialMode ? "serial"
                                    : "multithreading (N = " + std::to_string(parameters.nThreads) + ")")


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![20](https://badgen.net/badge/Size/20/orange) [![](https://gitlab.cern.ch/rest-for-physics/restg4/badges/lobis-command-line-params/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restg4/-/commits/lobis-command-line-params)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Implemented two optional command line parameter options for restG4:

-o output.root -> to select the output file, overwritting the rml
-g geometry.gdml -> to select the geometry file, overwritting the rml

These options can be useful for example in interactive environments such as a notebook where you would like to change these options for different cells without changing the rml.