### PR TITLE
Removed `using namespace std` from header files and fix errors

### DIFF
--- a/examples/11.Xrays/GetQE.C
+++ b/examples/11.Xrays/GetQE.C
@@ -97,4 +97,3 @@ Int_t GetQE(string inputFile) {
     cout << "All tests passed! [\033[32mOK\033[0m]\n";
     return 0;
 }
-

--- a/include/EventAction.h
+++ b/include/EventAction.h
@@ -2,7 +2,7 @@
 #ifndef EventAction_h
 #define EventAction_h 1
 
-using namespace std;
+
 
 #include <TH1D.h>
 #include <TRestGeant4Event.h>

--- a/include/EventAction.h
+++ b/include/EventAction.h
@@ -2,8 +2,6 @@
 #ifndef EventAction_h
 #define EventAction_h 1
 
-
-
 #include <TH1D.h>
 #include <TRestGeant4Event.h>
 #include <TRestGeant4Metadata.h>

--- a/include/PhysicsList.h
+++ b/include/PhysicsList.h
@@ -8,7 +8,7 @@
 #include <G4VModularPhysicsList.hh>
 #include <globals.hh>
 
-using namespace std;
+
 class G4VPhysicsConstructor;
 
 class PhysicsList : public G4VModularPhysicsList {

--- a/include/PhysicsList.h
+++ b/include/PhysicsList.h
@@ -8,7 +8,6 @@
 #include <G4VModularPhysicsList.hh>
 #include <globals.hh>
 
-
 class G4VPhysicsConstructor;
 
 class PhysicsList : public G4VModularPhysicsList {

--- a/include/PrimaryGeneratorAction.h
+++ b/include/PrimaryGeneratorAction.h
@@ -15,7 +15,7 @@
 #include "DetectorConstruction.h"
 #include "TRestGeant4Particle.h"
 
-using namespace std;
+
 
 const int nSpct = 3000;
 
@@ -36,7 +36,7 @@ class PrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction {
     void SetAngularDistribution(TH1D* ang) { fAngularDistribution = ang; }
 
    private:
-    vector<TRestGeant4Particle> fTempParticles;
+    std::vector<TRestGeant4Particle> fTempParticles;
 
     G4ParticleGun* fParticleGun;
     DetectorConstruction* fDetector;

--- a/include/PrimaryGeneratorAction.h
+++ b/include/PrimaryGeneratorAction.h
@@ -15,8 +15,6 @@
 #include "DetectorConstruction.h"
 #include "TRestGeant4Particle.h"
 
-
-
 const int nSpct = 3000;
 
 class G4Event;

--- a/include/RunAction.h
+++ b/include/RunAction.h
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <map>
 
-using namespace std;
+
 
 class G4Run;
 class PrimaryGeneratorAction;

--- a/include/RunAction.h
+++ b/include/RunAction.h
@@ -8,8 +8,6 @@
 #include <iostream>
 #include <map>
 
-
-
 class G4Run;
 class PrimaryGeneratorAction;
 

--- a/include/SteppingAction.h
+++ b/include/SteppingAction.h
@@ -12,7 +12,7 @@
 #include <globals.hh>
 #include <iostream>
 
-using namespace std;
+
 
 class SteppingAction : public G4UserSteppingAction {
    public:

--- a/include/SteppingAction.h
+++ b/include/SteppingAction.h
@@ -12,8 +12,6 @@
 #include <globals.hh>
 #include <iostream>
 
-
-
 class SteppingAction : public G4UserSteppingAction {
    public:
     SteppingAction();

--- a/src/DetectorConstruction.cxx
+++ b/src/DetectorConstruction.cxx
@@ -12,6 +12,8 @@
 
 #include "TRestGeant4GeometryInfo.h"
 
+using namespace std;
+
 extern TRestGeant4Event* restG4Event;
 extern TRestGeant4Metadata* restG4Metadata;
 

--- a/src/EventAction.cxx
+++ b/src/EventAction.cxx
@@ -27,11 +27,13 @@ void EventAction::BeginOfEventAction(const G4Event* geant4_event) {
 
     if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
         cout << "DEBUG: Start of event ID " << event_number << " (" << event_number + 1 << " of "
-             << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored." << endl;
+             << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored."
+             << endl;
     } else if ((restG4Metadata->PrintProgress() || restG4Metadata->GetVerboseLevel() >= REST_Info) &&
                geant4_event->GetEventID() % 10000 == 0) {
         cout << "INFO: Start of event ID " << event_number << " (" << event_number + 1 << " of "
-             << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored." << endl
+             << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored."
+             << endl
              << endl;
     }
 

--- a/src/Particles.cxx
+++ b/src/Particles.cxx
@@ -12,6 +12,8 @@
 #include <G4ShortLivedConstructor.hh>
 #include <G4SystemOfUnits.hh>
 
+using namespace std;
+
 Particles::Particles(const G4String& name) : G4VPhysicsConstructor(name) {}
 
 Particles::~Particles() {}

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -36,9 +36,10 @@
 #include <G4UAtomicDeexcitation.hh>
 #include <G4UnitsTable.hh>
 #include <G4UniversalFluctuation.hh>
-#include <G4IonTable.hh>
 
 #include "Particles.h"
+
+using namespace std;
 
 Int_t emCounter = 0;
 

--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -13,12 +13,12 @@
 #include <G4UnitsTable.hh>
 #include <Randomize.hh>
 
+using namespace std;
+
 extern TRestGeant4Metadata* restG4Metadata;
 extern TRestGeant4Event* restG4Event;
 
 Int_t face = 0;
-
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 double GeneratorRndm() { return G4UniformRand(); }
 
@@ -188,7 +188,7 @@ void PrimaryGeneratorAction::SetParticleDirection(Int_t n, TRestGeant4Particle p
         for (const auto& pair : g4_metadata_parameters::angular_dist_types_map) {
             cout << pair.first << ", ";
         }
-        cout << std::endl;
+        cout << endl;
         throw "Invalid angular distribution";
     }
     // generator type
@@ -204,7 +204,7 @@ void PrimaryGeneratorAction::SetParticleDirection(Int_t n, TRestGeant4Particle p
         for (const auto& pair : g4_metadata_parameters::generator_types_map) {
             cout << pair.first << ", ";
         }
-        cout << std::endl;
+        cout << endl;
         throw "Invalid generator type";
     }
 
@@ -390,7 +390,7 @@ void PrimaryGeneratorAction::SetParticleEnergy(Int_t n, TRestGeant4Particle p) {
         for (const auto& pair : g4_metadata_parameters::energy_dist_types_map) {
             cout << pair.first << ", ";
         }
-        cout << std::endl;
+        cout << endl;
         G4cout << "WARNING! Energy distribution type was not recognized. Setting "
                   "energy to 1keV"
                << G4endl;

--- a/src/RunAction.cxx
+++ b/src/RunAction.cxx
@@ -1,6 +1,5 @@
 
 #include "RunAction.h"
-#include "TRestRun.h"
 
 #include <PrimaryGeneratorAction.h>
 #include <TRestGeant4Metadata.h>
@@ -11,6 +10,10 @@
 #include <G4SystemOfUnits.hh>
 #include <G4UnitsTable.hh>
 #include <iomanip>
+
+#include "TRestRun.h"
+
+using namespace std;
 
 extern TRestGeant4Metadata* restG4Metadata;
 extern TRestRun* restRun;

--- a/src/SteppingAction.cxx
+++ b/src/SteppingAction.cxx
@@ -13,6 +13,8 @@
 #include <G4UnitsTable.hh>
 #include <globals.hh>
 
+using namespace std;
+
 extern TRestGeant4Event* restG4Event;
 extern TRestGeant4Metadata* restG4Metadata;
 extern TRestGeant4Track* restTrack;

--- a/src/TrackingAction.cxx
+++ b/src/TrackingAction.cxx
@@ -10,6 +10,8 @@
 #include "EventAction.h"
 #include "RunAction.h"
 
+using namespace std;
+
 extern TRestGeant4Metadata* restG4Metadata;
 extern TRestGeant4Event* restG4Event;
 extern TRestGeant4Track* restTrack;


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![24](https://badgen.net/badge/Size/24/orange) [![](https://gitlab.cern.ch/rest-for-physics/restg4/badges/lobis-remove-namespace-std-from-headers/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restg4/-/commits/lobis-remove-namespace-std-from-headers)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Needed for https://github.com/rest-for-physics/framework/pull/168. Read PR for additional info.