### PR TITLE
01.NLDBD/Validate.C removing obsolete libraries

### DIFF
--- a/examples/01.NLDBD/Validate.C
+++ b/examples/01.NLDBD/Validate.C
@@ -1,10 +1,5 @@
 
 Int_t Validate(string fname) {
-    gSystem->Load("libRestCore.so");
-    gSystem->Load("libRestMetadata.so");
-    gSystem->Load("libRestEvents.so");
-    gSystem->Load("libRestTools.so");
-
     TRestRun* run = new TRestRun(fname);
 
     if (run->GetParentRunNumber() != 0) {


### PR DESCRIPTION
A simple PR to remove obsolete libraries that cause output warnings when executing the validation macro.