### PR TITLE
Added check for Geant4 C++ std to be C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ find_package(Geant4 REQUIRED ui_all vis_all)
 include(${Geant4_USE_FILE})
 message("-- Found Geant4 version: ${Geant4_VERSION}")
 
+# Check Geant4 C++ standard is correct
+execute_process(COMMAND geant4-config --cxxstd OUTPUT_VARIABLE GEANT4_CXX_STD)
+if (NOT ${GEANT4_CXX_STD} MATCHES "17")
+    message(FATAL_ERROR "Geant4 installation was compiled with C++${GEANT4_CXX_STD} standard, but C++17 is required for REST")
+endif()
+
 # Fix for older Geant4 versions
 if (${Geant4_VERSION} VERSION_LESS 11.0.0)
     add_compile_definitions(GEANT4_VERSION_LESS_11_0_0)


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 6](https://badgen.net/badge/PR%20Size/Ok%3A%206/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-geant4-version-check/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-geant4-version-check) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-geant4-version-check/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-geant4-version-check) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-geant4-version-check/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-geant4-version-check)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes https://github.com/rest-for-physics/framework/issues/215

Adds check for the Geant4 c++ standard, if its not c++17, it gives an error.