### PR TITLE
Using `<filesystem>` to improve prints, updating examples with new `deg` angular unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if (NOT ${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
     set(INCLUDE_DIRS ${INCLUDE_DIRS} ${rest_include_dirs})
 endif ()
 
-set(LINK_LIBRARIES ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} RestFramework RestGeant4 stdc++fs)
+set(LINK_LIBRARIES ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} RestFramework RestGeant4)
 string(STRIP "${LINK_LIBRARIES}" LINK_LIBRARIES)
 
 file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cxx)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,10 @@ add_executable(${PROJECT_NAME} restG4.cxx ${sources} ${headers})
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARIES})
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${INCLUDE_DIRS})
 
-# Copy scripts to the build directory
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+        )
+
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/examples/
         DESTINATION ./examples/restG4/
         COMPONENT install
@@ -74,7 +77,6 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mac
         COMPONENT install
         )
 
-# Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 
 if (NOT ${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if (NOT ${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
     set(INCLUDE_DIRS ${INCLUDE_DIRS} ${rest_include_dirs})
 endif ()
 
-set(LINK_LIBRARIES ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} RestFramework RestGeant4)
+set(LINK_LIBRARIES ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} RestFramework RestGeant4 stdc++fs)
 string(STRIP "${LINK_LIBRARIES}" LINK_LIBRARIES)
 
 file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cxx)

--- a/examples/04.MuonScan/CosmicMuonsFromCircle.rml
+++ b/examples/04.MuonScan/CosmicMuonsFromCircle.rml
@@ -15,7 +15,7 @@
 
     <TRestGeant4Metadata name="restG4 run" title="MuonsFromCircle">
 
-        <parameter name="gdmlFile" value="/tmp/tmp.SC7mdqBb3e/source/packages/restG4/examples/04.MuonScan/setup.gdml"/>
+        <parameter name="gdmlFile" value="setup.gdml"/>
         <parameter name="subEventTimeDelay" value="100us"/>
 
         <parameter name="nEvents" value="5000"/>

--- a/examples/04.MuonScan/CosmicMuonsFromCircle.rml
+++ b/examples/04.MuonScan/CosmicMuonsFromCircle.rml
@@ -18,7 +18,7 @@
         <parameter name="gdmlFile" value="/tmp/tmp.SC7mdqBb3e/source/packages/restG4/examples/04.MuonScan/setup.gdml"/>
         <parameter name="subEventTimeDelay" value="100us"/>
 
-        <parameter name="nEvents" value="30000"/>
+        <parameter name="nEvents" value="5000"/>
 
         <parameter name="seed" value="17021981"/>
         <parameter name="saveAllEvents" value="false"/>
@@ -52,13 +52,13 @@
         <parameter name="maxEnergyRangeProductionCuts" value="1" units="GeV"/>
 
         <!-- EM Physics lists -->
-        <physicsList name="G4EmLivermorePhysics"></physicsList>
+        <physicsList name="G4EmLivermorePhysics"/>
         <!-- <physicsList name="G4EmPenelopePhysics"> </physicsList> -->
         <!-- <physicsList name="G4EmStandardPhysics_option3"> </physicsList> -->
 
         <!-- Decay physics lists -->
-        <physicsList name="G4DecayPhysics"></physicsList>
-        <physicsList name="G4RadioactiveDecayPhysics"></physicsList>
+        <physicsList name="G4DecayPhysics"/>
+        <physicsList name="G4RadioactiveDecayPhysics"/>
         <physicsList name="G4RadioactiveDecay">
             <option name="ICM" value="true"/>
             <option name="ARM" value="true"/>
@@ -66,10 +66,10 @@
 
         <!-- Hadron physics lists -->
 
-        <physicsList name="G4HadronElasticPhysicsHP"></physicsList>
-        <physicsList name="G4IonBinaryCascadePhysics"></physicsList>
-        <physicsList name="G4HadronPhysicsQGSP_BIC_HP"></physicsList>
-        <physicsList name="G4EmExtraPhysics"></physicsList>
+        <physicsList name="G4HadronElasticPhysicsHP"/>
+        <physicsList name="G4IonBinaryCascadePhysics"/>
+        <physicsList name="G4HadronPhysicsQGSP_BIC_HP"/>
+        <physicsList name="G4EmExtraPhysics"/>
 
     </TRestGeant4PhysicsLists>
 

--- a/examples/04.MuonScan/CosmicMuonsFromCircle.rml
+++ b/examples/04.MuonScan/CosmicMuonsFromCircle.rml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 
-<!--
-First concept author G. Luzón (16-11-2020) -->
-
 <restG4>
 
     <TRestRun name="CosmicMuonRun" title="A basic muon test with 2 active volumes">
@@ -18,19 +15,22 @@ First concept author G. Luzón (16-11-2020) -->
 
     <TRestGeant4Metadata name="restG4 run" title="MuonsFromCircle">
 
-        <parameter name="gdmlFile" value="setup.gdml"/>
+        <parameter name="gdmlFile" value="/tmp/tmp.SC7mdqBb3e/source/packages/restG4/examples/04.MuonScan/setup.gdml"/>
         <parameter name="subEventTimeDelay" value="100us"/>
 
-        <parameter name="nEvents" value="1000"/>
+        <parameter name="nEvents" value="30000"/>
 
+        <parameter name="seed" value="17021981"/>
         <parameter name="saveAllEvents" value="false"/>
         <parameter name="printProgress" value="true"/>
 
-        <generator type="surface" shape="circle" position="(0,0,50)cm" size="(15,0,0)cm" rotationAngle="0"
-                   rotationAxis="(1,0,0)">
+        <!-- From planar surface above detector (cosmic rays) -->
+        <generator type="surface" shape="circle"
+                   position="(0,100,0)mm" size="(400,0,0)mm"
+                   rotationAngle="90deg" rotationAxis="(1,0,0)">
             <source particle="mu-" excitedLevel="0.0" fullChain="on">
                 <energyDist type="TH1D" file="Muons.root" spctName="cosmicmuon"/>
-                <angularDist type="TH1D" file="CosmicAngles.root" spctName="Theta2" direction="(0,0,-1)"/>
+                <angularDist type="TH1D" file="CosmicAngles.root" spctName="Theta2" direction="(0,-1,0)"/>
             </source>
         </generator>
 

--- a/examples/04.MuonScan/ValidateCircle.C
+++ b/examples/04.MuonScan/ValidateCircle.C
@@ -1,5 +1,5 @@
 
-Int_t ValidateWall(string fname) {
+Int_t ValidateCircle(string fname) {
     gSystem->Load("/usr/local/rest-for-physics/lib/libRestFramework.so");
     gSystem->Load("/usr/local/rest-for-physics/lib/libRestGeant4.so");
 
@@ -18,9 +18,9 @@ Int_t ValidateWall(string fname) {
     for (Int_t n = 0; n < run.GetEntries(); n++) {
         run.GetEntry(n);
         Double_t x = event->GetPrimaryEventOrigin().X();
-        Double_t y = event->GetPrimaryEventOrigin().Y();
+        Double_t z = event->GetPrimaryEventOrigin().Z();
 
-        const auto r = TMath::Sqrt(x * x + y * y) / 100;  // cm
+        const auto r = TMath::Sqrt(x * x + z * z) / 100;  // cm
 
         rMean += r / run.GetEntries();
         if (r < rMin) {
@@ -31,27 +31,27 @@ Int_t ValidateWall(string fname) {
         }
     }
 
-    if (rMean < 0.8 || rMean > 1.2) {
+    if (rMean < 2.75 || rMean > 3.25) {
         cout << "The average radius of the distribution is wrong!" << endl;
         cout << "R_mean (cm): " << rMean << endl;
         return 5;
     }
 
-    if (rMin > 0.15) {
+    if (rMin > 0.5) {
         cout << "The minimum radius of the distribution is wrong!" << endl;
         cout << "R_min (cm): " << rMin << endl;
         return 6;
     }
 
-    if (rMax > 1.5 || rMax < 1.35) {
+    if (rMax > 4.0 || rMax < 3.75) {
         cout << "The maximum radius of the distribution is wrong!" << endl;
         cout << "R_max (cm): " << rMax << endl;
         return 7;
     }
 
     cout << "Run entries: " << run.GetEntries() << endl;
-    if (run.GetEntries() < 350 || run.GetEntries() > 450) {
-        cout << "The number of entries is not between 350 and 450!" << endl;
+    if (run.GetEntries() < 600 || run.GetEntries() > 750) {
+        cout << "The number of entries is wrong!" << endl;
         cout << "Number of entries : " << run.GetEntries() << endl;
         return 8;
     }

--- a/restG4.cxx
+++ b/restG4.cxx
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 
 #include "CommandLineSetup.h"
 #include "DetectorConstruction.h"
@@ -384,7 +385,7 @@ int main(int argc, char** argv) {
 
     systime = time(nullptr);
     restRun->SetEndTimeStamp((Double_t)systime);
-    TString Filename = restRun->GetOutputFileName();
+    TString filename = TString(filesystem::weakly_canonical(restRun->GetOutputFileName().Data()));
 
     restRun->UpdateOutputFile();
     restRun->CloseFile();
@@ -414,7 +415,7 @@ int main(int argc, char** argv) {
         sleep(5);
 
         // Then we just add the geometry
-        auto file = new TFile(Filename, "update");
+        auto file = new TFile(filename, "update");
         TGeoManager* geoManager = gdml->CreateGeoManager();
 
         file->cd();
@@ -431,7 +432,7 @@ int main(int argc, char** argv) {
         printf("Writing geometry ... \n");
     }
 
-    cout << "============== Generated file: " << Filename << " ==============" << endl;
+    cout << "============== Generated file: " << filename << " ==============" << endl;
     auto end_time = chrono::steady_clock::now();
     cout << "Elapsed time: " << chrono::duration_cast<chrono::seconds>(end_time - start_time).count()
          << " seconds" << endl;

--- a/src/RunAction.cxx
+++ b/src/RunAction.cxx
@@ -37,7 +37,7 @@ void RunAction::EndOfRunAction(const G4Run* run) {
     // G4double eprimary = fPrimary->GetParticleGun()->GetParticleEnergy();
 
     G4cout << "======================== run summary ======================";
-    G4cout << "\n" << nbEvents << " Events simulated, " << restRun->GetEntries() << "Events stored\n";
+    G4cout << "\n" << nbEvents << " Events simulated, " << restRun->GetEntries() << " Events stored\n";
     G4cout << "===========================================================";
     G4cout << G4endl;
 


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 31](https://badgen.net/badge/PR%20Size/Ok%3A%2031/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-degree-unit/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-degree-unit) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-degree-unit/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-degree-unit) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-degree-unit/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-degree-unit)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Updated example with new `deg` unit defined in https://github.com/rest-for-physics/framework/pull/221 so that examples are easier to understand.

Improved prints using the `<filesystem>` library which should always be available since REST requires C++17. This PR also links to `stdc++fs` which may be necessary if using old compiler version.

Update: this PR https://github.com/rest-for-physics/framework/pull/226 links the whole framework to `std++fs` (needed for systems with old compiler version such as `gcc 8`), so we don't need to explicitly link here.