### PR TITLE
Renaming endl to RESTendl and other logger functions

### DIFF
--- a/src/EventAction.cxx
+++ b/src/EventAction.cxx
@@ -25,11 +25,11 @@ void EventAction::BeginOfEventAction(const G4Event* geant4_event) {
 
     restG4Metadata->GetVerboseLevel();
 
-    if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "DEBUG: Start of event ID " << event_number << " (" << event_number + 1 << " of "
              << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored."
              << endl;
-    } else if ((restG4Metadata->PrintProgress() || restG4Metadata->GetVerboseLevel() >= REST_Info) &&
+    } else if ((restG4Metadata->PrintProgress() || restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) &&
                geant4_event->GetEventID() % 10000 == 0) {
         cout << "INFO: Start of event ID " << event_number << " (" << event_number + 1 << " of "
              << restG4Metadata->GetNumberOfEvents() << "). " << restRun->GetEntries() << " Events stored."
@@ -59,7 +59,7 @@ void EventAction::BeginOfEventAction(const G4Event* geant4_event) {
 void EventAction::EndOfEventAction(const G4Event* geant4_event) {
     G4int event_number = geant4_event->GetEventID();
 
-    if (restG4Metadata->GetVerboseLevel() >= REST_Extreme) {
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
         restG4Event->PrintEvent();
     }
 
@@ -84,13 +84,13 @@ void EventAction::EndOfEventAction(const G4Event* geant4_event) {
              total_deposited_energy < maximum_energy_stored) ||
             restG4Metadata->GetSaveAllEvents();
 
-        if (restG4Metadata->GetVerboseLevel() >= REST_Info) {
+        if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) {
             string debug_level = "INFO";
-            if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+            if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 debug_level = "DEBUG";
             }
 
-            if (is_sensitive || restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+            if (is_sensitive || restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << debug_level
                      << ": Energy deposited in ACTIVE and SENSITIVE volumes: " << total_deposited_energy
                      << " keV" << endl;
@@ -114,7 +114,7 @@ void EventAction::EndOfEventAction(const G4Event* geant4_event) {
                 analysis_tree->Fill();
             } else {
                 // analysis tree is not found (nullptr)
-                if (restG4Metadata->GetVerboseLevel() >= REST_Warning) {
+                if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning) {
                     cout << "WARNING: Analysis tree is not found ('nullptr'). Cannot write event info"
                          << endl;
                 }
@@ -125,20 +125,20 @@ void EventAction::EndOfEventAction(const G4Event* geant4_event) {
                 event_tree->Fill();
             } else {
                 // event tree is not found (nullptr)
-                if (restG4Metadata->GetVerboseLevel() >= REST_Warning) {
+                if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning) {
                     cout << "WARNING: Event tree is not found ('nullptr'). Cannot write event info" << endl;
                 }
             }
         }
     }
 
-    if (restG4Metadata->GetVerboseLevel() >= REST_Info) {
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) {
         string debug_level = "INFO";
-        if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+        if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             debug_level = "DEBUG";
         }
 
-        if (is_sensitive || restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+        if (is_sensitive || restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << debug_level
                  << ": Events depositing energy in sensitive volume: " << sensitive_volume_hits_count << "/"
                  << event_number + 1 << endl;

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -90,14 +90,14 @@ void PhysicsList::InitializePhysicsLists() {
     // Decay physics and all particles
     if (restPhysList->FindPhysicsList("G4DecayPhysics") >= 0) {
         fDecPhysicsList = new G4DecayPhysics();
-    } else if (restPhysList->GetVerboseLevel() >= REST_Debug) {
+    } else if (restPhysList->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         G4cout << "restG4. PhysicsList. G4DecayPhysics is not enabled!!" << G4endl;
     }
 
     // RadioactiveDecay physicsList
     if (restPhysList->FindPhysicsList("G4RadioactiveDecayPhysics") >= 0) {
         fRadDecPhysicsList = new G4RadioactiveDecayPhysics();
-    } else if (restPhysList->GetVerboseLevel() >= REST_Debug) {
+    } else if (restPhysList->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         G4cout << "restG4. PhysicsList. G4RadioactiveDecayPhysics is not enabled!!" << G4endl;
     }
 
@@ -122,7 +122,7 @@ void PhysicsList::InitializePhysicsLists() {
         emCounter++;
     }
 
-    if (restPhysList->GetVerboseLevel() >= REST_Essential && emCounter == 0) {
+    if (restPhysList->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Essential && emCounter == 0) {
         G4cout << "REST WARNING : No electromagenetic physics list has been enabled!!" << G4endl;
     }
 
@@ -224,7 +224,7 @@ void PhysicsList::ConstructProcess() {
         else if (restPhysList->GetPhysicsListOptionValue("G4RadioactiveDecay", "ICM") == "false") {
             radioactiveDecay->SetICM(false);
         }  // Internal Conversion
-        else if (restPhysList->GetVerboseLevel() >= REST_Essential) {
+        else if (restPhysList->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Essential) {
             G4cout << "REST WARNING. restG4. PhysicsList. G4RadioactiveDecay. Option "
                       "ICM not defined."
                    << G4endl;
@@ -237,7 +237,7 @@ void PhysicsList::ConstructProcess() {
         else if (restPhysList->GetPhysicsListOptionValue("G4RadioactiveDecay", "ARM") == "false") {
             radioactiveDecay->SetARM(false);
         }  // Internal Conversion
-        else if (restPhysList->GetVerboseLevel() >= REST_Essential) {
+        else if (restPhysList->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Essential) {
             G4cout << "REST WARNING. restG4. PhysicsList. G4RadioactiveDecay. Option "
                       "ARM not defined."
                    << G4endl;

--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -85,7 +85,7 @@ void PrimaryGeneratorAction::SetGeneratorSpatialDensity(TString str) {
 }
 
 void PrimaryGeneratorAction::GeneratePrimaries(G4Event* geant4_event) {
-    if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "DEBUG: Primary generation" << endl;
     }
     // We have to initialize here and not in start of the event because
@@ -128,7 +128,7 @@ G4ParticleDefinition* PrimaryGeneratorAction::SetParticleDefinition(Int_t n, TRe
 
     Int_t charge = p.GetParticleCharge();
 
-    if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "DEBUG: Particle name: " << particle_name << endl;
         // cout << "DEBUG: Particle charge: " << charge << endl;
         cout << "DEBUG: Particle excited energy: " << excited_energy << " keV" << endl;
@@ -172,7 +172,7 @@ void PrimaryGeneratorAction::SetParticleDirection(Int_t n, TRestGeant4Particle p
     angular_dist_type_name = g4_metadata_parameters::CleanString(angular_dist_type_name);
     g4_metadata_parameters::angular_dist_types angular_dist_type;
 
-    if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "DEBUG: Angular distribution: " << angular_dist_type_name << endl;
     }
     // we first check if it is a valid parameter
@@ -355,7 +355,7 @@ void PrimaryGeneratorAction::SetParticleDirection(Int_t n, TRestGeant4Particle p
     TVector3 eventDirection(direction.x(), direction.y(), direction.z());
     restG4Event->SetPrimaryEventDirection(eventDirection);
 
-    if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "DEBUG: Event direction (normalized): "
              << "(" << restG4Event->GetPrimaryEventDirection(n).X() << ", "
              << restG4Event->GetPrimaryEventDirection(n).Y() << ", "
@@ -372,7 +372,7 @@ void PrimaryGeneratorAction::SetParticleEnergy(Int_t n, TRestGeant4Particle p) {
     auto energy_dist_type_name = (string)restG4Metadata->GetParticleSource(n)->GetEnergyDistType();
     energy_dist_type_name = g4_metadata_parameters::CleanString(energy_dist_type_name);
 
-    if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "DEBUG: Energy distribution: " << energy_dist_type_name << endl;
     }
 
@@ -441,7 +441,7 @@ void PrimaryGeneratorAction::SetParticleEnergy(Int_t n, TRestGeant4Particle p) {
 
     restG4Event->SetPrimaryEventEnergy(energy / keV);
 
-    if (restG4Metadata->GetVerboseLevel() >= REST_Debug)
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         cout << "DEBUG: Particle energy: " << energy / keV << " keV" << endl;
 }
 
@@ -511,7 +511,7 @@ void PrimaryGeneratorAction::SetParticlePosition() {
     TVector3 eventPosition(x, y, z);
     restG4Event->SetPrimaryEventOrigin(eventPosition);
 
-    if (restG4Metadata->GetVerboseLevel() >= REST_Debug) {
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "DEBUG: Event origin: "
              << "(" << restG4Event->GetPrimaryEventOrigin().X() << ", "
              << restG4Event->GetPrimaryEventOrigin().Y() << ", " << restG4Event->GetPrimaryEventOrigin().Z()

--- a/src/SteppingAction.cxx
+++ b/src/SteppingAction.cxx
@@ -144,7 +144,7 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
         // We check if the hit must be stored and keep it on restG4Track
         for (int volID = 0; volID < restG4Metadata->GetNumberOfActiveVolumes(); volID++) {
             if (restG4Event->isVolumeStored(volID)) {
-                if (restG4Metadata->GetVerboseLevel() >= REST_Extreme)
+                if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme)
                     G4cout << "Step volume :" << nom_vol << "::("
                            << (G4String)restG4Metadata->GetActiveVolumeName(volID) << ")" << G4endl;
 
@@ -153,7 +153,7 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
 
                 if (isActiveVolume) {
                     volume = volID;
-                    if (restG4Metadata->GetVerboseLevel() >= REST_Extreme) G4cout << "Storing hit" << G4endl;
+                    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) G4cout << "Storing hit" << G4endl;
                     restTrack->AddG4Hit(hitPosition, ener_dep / keV, hit_global_time, pcsID, volID, eKin,
                                         momentumDirection);
                     alreadyStored = true;

--- a/src/TrackingAction.cxx
+++ b/src/TrackingAction.cxx
@@ -39,7 +39,7 @@ TrackingAction::TrackingAction(RunAction* runAction, EventAction* eventAction)
 TrackingAction::~TrackingAction() {}
 
 void TrackingAction::PreUserTrackingAction(const G4Track* track) {
-    if (restG4Metadata->GetVerboseLevel() >= REST_Extreme)
+    if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme)
         if (track->GetTrackID() % 10 == 0) {
             cout << "EXTREME: Processing track " << track->GetTrackID() << endl;
         }


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 26](https://badgen.net/badge/PR%20Size/Ok%3A%2026/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/RESTendl) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/RESTendl) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/RESTendl)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related with https://github.com/rest-for-physics/framework/pull/225:
- Renamed custom `endl` to `RESTendl`
- Renamed other logger functions
  - `info` --> `RESTInfo`  
  - `debug` --> `RESTDebug`
  - `essential` --> `RESTEssential`
  - `warning` --> `RESTWarning`
  - `fout` --> `RESTcout`
  - `ferr` --> `RESTError`