### PR TITLE
Added CI job to build restG4 with framework on master ref

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -453,3 +453,28 @@ jobs:
           export REST_ISOTOPE=Be7
           restG4 singleDecay.rml
           restRoot -b -q Validate.C'("Run00002_Be7_SingleChainDecay.root", 1)'
+
+  # Build restG4 with `master` version of framework. This job can fail without failing the workflow
+  framework-install-master:
+    name: Install framework with restG4 on `master` version of framework just with Geant4lib (on the ref found on framework)
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+    steps:
+      - name: Checkout framework
+        run: |
+          git clone https://github.com/rest-for-physics/framework.git ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
+          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
+          git log -1 --stat # should always be on master branch
+      - uses: actions/checkout@v3
+      - name: Setup, build and install
+        continue-on-error: true
+        run: |
+          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
+          git submodule init source/libraries/geant4 && git submodule update source/libraries/geant4
+          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
+          rm -rf source/packages/restG4/ && cp -r $GITHUB_WORKSPACE source/packages/restG4
+          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
+          mkdir -p ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/build && cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/build
+          cmake ../ -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DREST_G4=ON -DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }}
+          make -j4 install


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 25](https://badgen.net/badge/PR%20Size/Ok%3A%2025/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-actions-add-master-check/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-actions-add-master-check) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-actions-add-master-check/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-actions-add-master-check) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-actions-add-master-check/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-actions-add-master-check) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-actions-add-master-check)](https://github.com/rest-for-physics/restG4/commits/lobis-actions-add-master-check)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This job can optionally fail, so it will never make the pipeline fail.

If this job passes its safe to merge `restG4` to `master` and the `master` pipeline for `restG4` won't fail (or atleast this is the idea).