### PR TITLE
Removed biasing related code

### DIFF
--- a/include/SimulationManager.h
+++ b/include/SimulationManager.h
@@ -18,14 +18,6 @@ class SimulationManager {
     TRestGeant4Event *fRestGeant4Event = nullptr, *fRestGeant4SubEvent = nullptr;
     TRestGeant4Metadata* fRestGeant4Metadata = nullptr;
     TRestGeant4PhysicsLists* fRestGeant4PhysicsLists = nullptr;
-    Int_t fBiasing = 0;
-
-    static const Int_t maxBiasingVolumes = 50;
-
-    // These histograms would be better placed inside TRestGeant4BiasingVolume
-    TH1D* biasingSpectrum[maxBiasingVolumes];
-    TH1D* angularDistribution[maxBiasingVolumes];
-    TH2D* spatialDistribution[maxBiasingVolumes];
 
     TH1D initialEnergySpectrum;
     TH1D initialAngularDistribution;

--- a/include/SteppingAction.h
+++ b/include/SteppingAction.h
@@ -4,7 +4,6 @@
 
 #include <TH1D.h>
 #include <TH2D.h>
-#include <TRestGeant4BiasingVolume.h>
 
 #include <G4RunManager.hh>
 #include <G4UserSteppingAction.hh>
@@ -19,34 +18,13 @@ class SteppingAction : public G4UserSteppingAction {
     SteppingAction(SimulationManager*);
     ~SteppingAction();
 
-    void SetBiasingVolume(const TRestGeant4BiasingVolume& biasVol) { restBiasingVolume = biasVol; }
-    void SetBiasingSpectrum(TH1D* bSpectrum) { fBiasingSpectrum = bSpectrum; }
-    void SetAngularDistribution(TH1D* aDist) { fAngularDistribution = aDist; }
-    void SetSpatialDistribution(TH2D* sDist) { fSpatialDistribution = sDist; }
     void UserSteppingAction(const G4Step*) override;
-
-    TRestGeant4BiasingVolume GetBiasingVolume() { return restBiasingVolume; }
-    TH1D* GetBiasingSpectrum() { return fBiasingSpectrum; }
-    TH1D* GetAngularDistribution() { return fAngularDistribution; }
-    TH2D* GetSpatialDistribution() { return fSpatialDistribution; }
 
    private:
     SimulationManager* fSimulationManager;
 
     G4String nom_vol, nom_part, nom_proc;
-    G4double dif_ener, ener_dep, ener, eKin;
-    G4int trackID, parentID;
-
-    TH1D* fBiasingSpectrum;
-    TH1D* fAngularDistribution;
-    TH2D* fSpatialDistribution;
-
-    static Double_t absDouble(Double_t x) {
-        if (x < 0) return -x;
-        return x;
-    }
-
-    TRestGeant4BiasingVolume restBiasingVolume;
+    G4double ener_dep, eKin;
 
     G4ThreeVector previousDirection;
 };

--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -97,7 +97,6 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* event) {
     TRestGeant4Event* subRestG4Event = simulationManager->fRestGeant4SubEvent;
     TRestGeant4Metadata* restG4Metadata = simulationManager->fRestGeant4Metadata;
     TRestGeant4PhysicsLists* restPhysList = simulationManager->fRestGeant4PhysicsLists;
-    Int_t& biasing = simulationManager->fBiasing;
 
     if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "DEBUG: Primary generation" << endl;
@@ -143,7 +142,6 @@ G4ParticleDefinition* PrimaryGeneratorAction::SetParticleDefinition(Int_t n, TRe
     TRestGeant4Event* subRestG4Event = simulationManager->fRestGeant4SubEvent;
     TRestGeant4Metadata* restG4Metadata = simulationManager->fRestGeant4Metadata;
     TRestGeant4PhysicsLists* restPhysList = simulationManager->fRestGeant4PhysicsLists;
-    Int_t& biasing = simulationManager->fBiasing;
 
     auto particle_name = (string)p.GetParticleName();
 
@@ -193,7 +191,6 @@ void PrimaryGeneratorAction::SetParticleDirection(Int_t n, TRestGeant4Particle p
     TRestGeant4Event* restG4Event = simulationManager->fRestGeant4Event;
     TRestGeant4Event* subRestG4Event = simulationManager->fRestGeant4SubEvent;
     TRestGeant4Metadata* restG4Metadata = simulationManager->fRestGeant4Metadata;
-    Int_t& biasing = simulationManager->fBiasing;
 
     G4ThreeVector direction;
     // TODO: maybe reduce code redundancy by defining some functions?
@@ -405,7 +402,6 @@ void PrimaryGeneratorAction::SetParticleEnergy(Int_t n, TRestGeant4Particle p) {
     TRestGeant4Event* restG4Event = simulationManager->fRestGeant4Event;
     TRestGeant4Event* subRestG4Event = simulationManager->fRestGeant4SubEvent;
     TRestGeant4Metadata* restG4Metadata = simulationManager->fRestGeant4Metadata;
-    Int_t& biasing = simulationManager->fBiasing;
 
     Double_t energy = 0;
 
@@ -493,7 +489,6 @@ void PrimaryGeneratorAction::SetParticlePosition() {
     TRestGeant4Event* restG4Event = simulationManager->fRestGeant4Event;
     TRestGeant4Event* subRestG4Event = simulationManager->fRestGeant4SubEvent;
     TRestGeant4Metadata* restG4Metadata = simulationManager->fRestGeant4Metadata;
-    Int_t& biasing = simulationManager->fBiasing;
 
     double x = 0, y = 0, z = 0;
     string generator_type_name = (string)restG4Metadata->GetGeneratorType();

--- a/src/SteppingAction.cxx
+++ b/src/SteppingAction.cxx
@@ -17,23 +17,15 @@
 
 using namespace std;
 
-SteppingAction::SteppingAction(SimulationManager* simulationManager) : fSimulationManager(simulationManager) {
-    TRestGeant4Metadata* restG4Metadata = fSimulationManager->fRestGeant4Metadata;
-    Int_t& biasing = fSimulationManager->fBiasing;
-
-    if (biasing > 1) restBiasingVolume = restG4Metadata->GetBiasingVolume(biasing - 1);
-}
+SteppingAction::SteppingAction(SimulationManager* simulationManager)
+    : fSimulationManager(simulationManager) {}
 
 SteppingAction::~SteppingAction() {}
 
 void SteppingAction::UserSteppingAction(const G4Step* aStep) {
-    TRestRun* restRun = fSimulationManager->fRestRun;
     TRestGeant4Track* restTrack = fSimulationManager->fRestGeant4Track;
     TRestGeant4Event* restG4Event = fSimulationManager->fRestGeant4Event;
-    TRestGeant4Event* subRestG4Event = fSimulationManager->fRestGeant4SubEvent;
     TRestGeant4Metadata* restG4Metadata = fSimulationManager->fRestGeant4Metadata;
-    TRestGeant4PhysicsLists* restPhysList = fSimulationManager->fRestGeant4PhysicsLists;
-    Int_t& biasing = fSimulationManager->fBiasing;
 
     // Variables that describe a step are taken.
     nom_vol = restG4Metadata->GetGeant4GeometryInfo()->GetAlternativeNameFromGeant4PhysicalName(
@@ -71,111 +63,48 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
     nom_proc = aStep->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName();
 
     G4Track* aTrack = aStep->GetTrack();
-    parentID = aTrack->GetParentID();
-    trackID = aTrack->GetTrackID();
 
     Double_t x = aTrack->GetPosition().x() / mm;
     Double_t y = aTrack->GetPosition().y() / mm;
     Double_t z = aTrack->GetPosition().z() / mm;
 
-    //   G4cout << "Step direction : " << aTrack->GetMomentumDirection() <<
-    //   G4endl;
-
-    if (biasing > 0) {
-        // In biasing mode we do not store hits. Just check if we observe a gamma
-        // inside the volume
-        if (restBiasingVolume.isInside(x, y, z) && nom_part == "gamma") {
-            Double_t eKinetic = aStep->GetPreStepPoint()->GetKineticEnergy() / keV;
-
-            // we add the gamma energy to the energy spectrum
-            if (eKinetic > restBiasingVolume.GetMinEnergy() && eKinetic < restBiasingVolume.GetMaxEnergy()) {
-                G4ThreeVector position = aStep->GetPreStepPoint()->GetPosition();
-                G4ThreeVector positionNorm = -aStep->GetPreStepPoint()->GetPosition().unit();
-                G4ThreeVector momentum = aStep->GetPreStepPoint()->GetMomentumDirection();
-
-                Double_t angle;
-                if (restBiasingVolume.GetBiasingVolumeType() == "virtualBox") {
-                    if (absDouble(position.x()) > absDouble(position.y()) &&
-                        absDouble(position.x()) > absDouble(position.z())) {
-                        // launching event from side x
-                        if (position.x() > 0)
-                            positionNorm.set(-1, 0, 0);
-                        else
-                            positionNorm.set(1, 0, 0);
-
-                    } else if (absDouble(position.y()) > absDouble(position.x()) &&
-                               absDouble(position.y()) > absDouble(position.z())) {
-                        // launching event from side y
-                        if (position.y() > 0)
-                            positionNorm.set(0, -1, 0);
-                        else
-                            positionNorm.set(0, 1, 0);
-                    } else {
-                        // launching event from side y
-                        if (position.z() > 0)
-                            positionNorm.set(0, 0, -1);
-                        else
-                            positionNorm.set(0, 0, 1);
-                    }
-                }
-                angle = momentum.angle(positionNorm);
-
-                fBiasingSpectrum->Fill(eKinetic);
-                fAngularDistribution->Fill(angle);
-
-                if (restBiasingVolume.GetBiasingVolumeType() == "virtualSphere")
-                    fSpatialDistribution->Fill(position.getPhi(), position.getTheta());
-                else
-                    fSpatialDistribution->Fill(position.x(), position.y());
-            }
-
-            // and we cancel the track
-            //           aTrack->SetTrackStatus( fStopAndKill );
-            aTrack->SetTrackStatus(fKillTrackAndSecondaries);
-
-            // previousDirection = momentum;
-        }
-
-    } else {
-        if ((G4String)restG4Metadata->GetSensitiveVolume() == nom_vol) {
-            restG4Event->AddEnergyToSensitiveVolume(ener_dep / keV);
-        }
-
-        TVector3 hitPosition(x, y, z);
-        Int_t pcsID = restTrack->GetProcessID(nom_proc);
-        Double_t hit_global_time = aStep->GetPreStepPoint()->GetGlobalTime() / second;
-        G4ThreeVector momentum = aStep->GetPreStepPoint()->GetMomentumDirection();
-        TVector3 momentumDirection = TVector3(momentum.x(), momentum.y(), momentum.z());  //.Unit();
-
-        Int_t volume = -1;
-        Bool_t alreadyStored = false;
-        // We check if the hit must be stored and keep it on restG4Track
-        for (int volID = 0; volID < restG4Metadata->GetNumberOfActiveVolumes(); volID++) {
-            if (restG4Event->isVolumeStored(volID)) {
-                if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme)
-                    G4cout << "Step volume :" << nom_vol << "::("
-                           << (G4String)restG4Metadata->GetActiveVolumeName(volID) << ")" << G4endl;
-
-                // We store the hit if we have activated in the config
-                Bool_t isActiveVolume = (nom_vol == (G4String)restG4Metadata->GetActiveVolumeName(volID));
-
-                if (isActiveVolume) {
-                    volume = volID;
-                    if (restG4Metadata->GetVerboseLevel() >=
-                        TRestStringOutput::REST_Verbose_Level::REST_Extreme)
-                        G4cout << "Storing hit" << G4endl;
-                    restTrack->AddG4Hit(hitPosition, ener_dep / keV, hit_global_time, pcsID, volID, eKin,
-                                        momentumDirection);
-                    alreadyStored = true;
-                }
-            }
-        }
-
-        // See issue #65.
-        // If the radioactive decay occurs in a non-active volume then the id will be -1
-        Bool_t isDecay = (nom_proc == (G4String) "RadioactiveDecay");
-        if (!alreadyStored && isDecay)
-            restTrack->AddG4Hit(hitPosition, ener_dep / keV, hit_global_time, pcsID, volume, eKin,
-                                momentumDirection);
+    if ((G4String)restG4Metadata->GetSensitiveVolume() == nom_vol) {
+        restG4Event->AddEnergyToSensitiveVolume(ener_dep / keV);
     }
+
+    TVector3 hitPosition(x, y, z);
+    Int_t pcsID = restTrack->GetProcessID(nom_proc);
+    Double_t hit_global_time = aStep->GetPreStepPoint()->GetGlobalTime() / second;
+    G4ThreeVector momentum = aStep->GetPreStepPoint()->GetMomentumDirection();
+    TVector3 momentumDirection = TVector3(momentum.x(), momentum.y(), momentum.z());  //.Unit();
+
+    Int_t volume = -1;
+    Bool_t alreadyStored = false;
+    // We check if the hit must be stored and keep it on restG4Track
+    for (int volID = 0; volID < restG4Metadata->GetNumberOfActiveVolumes(); volID++) {
+        if (restG4Event->isVolumeStored(volID)) {
+            if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme)
+                G4cout << "Step volume :" << nom_vol << "::("
+                       << (G4String)restG4Metadata->GetActiveVolumeName(volID) << ")" << G4endl;
+
+            // We store the hit if we have activated in the config
+            Bool_t isActiveVolume = (nom_vol == (G4String)restG4Metadata->GetActiveVolumeName(volID));
+
+            if (isActiveVolume) {
+                volume = volID;
+                if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme)
+                    G4cout << "Storing hit" << G4endl;
+                restTrack->AddG4Hit(hitPosition, ener_dep / keV, hit_global_time, pcsID, volID, eKin,
+                                    momentumDirection);
+                alreadyStored = true;
+            }
+        }
+    }
+
+    // See issue #65.
+    // If the radioactive decay occurs in a non-active volume then the id will be -1
+    Bool_t isDecay = (nom_proc == (G4String) "RadioactiveDecay");
+    if (!alreadyStored && isDecay)
+        restTrack->AddG4Hit(hitPosition, ener_dep / keV, hit_global_time, pcsID, volume, eKin,
+                            momentumDirection);
 }

--- a/src/TrackingAction.cxx
+++ b/src/TrackingAction.cxx
@@ -46,7 +46,6 @@ void TrackingAction::PreUserTrackingAction(const G4Track* track) {
     TRestGeant4Event* subRestG4Event = fSimulationManager->fRestGeant4SubEvent;
     TRestGeant4Metadata* restG4Metadata = fSimulationManager->fRestGeant4Metadata;
     TRestGeant4PhysicsLists* restPhysList = fSimulationManager->fRestGeant4PhysicsLists;
-    Int_t& biasing = fSimulationManager->fBiasing;
 
     if (restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
         if (track->GetTrackID() % 10 == 0) {


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 37](https://badgen.net/badge/PR%20Size/Ok%3A%2037/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-remove-biasing/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-remove-biasing) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-remove-biasing/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-remove-biasing) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-remove-biasing/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-remove-biasing) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-remove-biasing)](https://github.com/rest-for-physics/restG4/commits/lobis-remove-biasing)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR removes biasing related code as it's in my opinion confusing and possibly not working at the moment. This is to help in the big refactoring necessary to support multithreading, it can be added back later if necessary.

In the future it is extected to implement a biasing functionality based on the Geant4 biasing examples, which will be somewhat different from this implementation.