### PR TITLE
Fixed installation on Sultan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mac
         )
 
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
+install(TARGETS ${LIBRARY} DESTINATION lib)
 
 if (NOT ${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
     set(package_added "${PROJECT_NAME} ")


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-fix-sultan-install/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-fix-sultan-install) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-fix-sultan-install/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-fix-sultan-install) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-fix-sultan-install/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-fix-sultan-install) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-fix-sultan-install)](https://github.com/rest-for-physics/restG4/commits/lobis-fix-sultan-install)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR adds the newly created `libRestRestG4.so` to the installation directory, fixing installation issues on our server.

However before this PR the framework was working correctly in the docker container and the validation pipeline was passing, it would be nice to understand why.