### PR TITLE
Low energy EM updates and bug fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,13 +66,13 @@ Build Standalone:
 Load REST Libraries:
   stage: Load REST Libraries
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - restRoot -b -q
 
 01.NLDBD:
   stage: Run Examples
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - cd ${CI_PROJECT_DIR}/install/examples/restG4/01.NLDBD/
     - restG4 NLDBD.rml
     - geant4-config --version
@@ -81,7 +81,7 @@ Load REST Libraries:
 03.Fluorescence:
   stage: Run Examples
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - cd ${CI_PROJECT_DIR}/install/examples/restG4/03.Fluorescence/
     - restG4 gamma.rml
     - restManager --c g4Analysis.rml --f Run00111_Gamma_Fluorescence.root
@@ -91,7 +91,7 @@ Load REST Libraries:
 04.MuonScan:
   stage: Run Examples
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - cd ${CI_PROJECT_DIR}/install/examples/restG4/04.MuonScan/
     - restG4 Muon.rml
     - geant4-config --version
@@ -104,7 +104,7 @@ Load REST Libraries:
 05.PandaXIII:
   stage: Run Examples
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - cd ${CI_PROJECT_DIR}/install/examples/restG4/05.PandaXIII/
     - restG4 Xe136bb0n.rml
     - restRoot -b -q Validate.C'("Xe136bb0n_n2E06.root")'
@@ -112,7 +112,7 @@ Load REST Libraries:
 06.IonRecoils:
   stage: Run Examples
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - cd ${CI_PROJECT_DIR}/install/examples/restG4/06.IonRecoils/
     - restG4 recoils.rml
     - restRoot -b -q Validate.C'("Run00001_F20_Recoils.root")'
@@ -120,7 +120,7 @@ Load REST Libraries:
 07.FullChainDecay:
   stage: Run Examples
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - cd ${CI_PROJECT_DIR}/install/examples/restG4/07.FullChainDecay/
     - restG4 fullChain.rml
     - restG4 singleDecay.rml
@@ -133,7 +133,7 @@ Load REST Libraries:
 08.Alphas:
   stage: Run Examples
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - cd ${CI_PROJECT_DIR}/install/examples/restG4/08.Alphas/
     - mkdir data
     - export REST_ENERGY=5
@@ -154,7 +154,7 @@ Load REST Libraries:
 09.Pb210_Shielding:
   stage: Run Examples
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - cd ${CI_PROJECT_DIR}/install/examples/restG4/09.Pb210_Shield/
     - restG4 Pb210.rml
     - restRoot -b -q Validate.C'("Run00001_Pb210_Shielding.root")'
@@ -162,7 +162,7 @@ Load REST Libraries:
 10.Geometries:
   stage: Run Examples
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - cd ${CI_PROJECT_DIR}/install/examples/restG4/10.Geometries/
     - restG4 Assembly.rml
     - restRoot -b -q Validate.C'("Run00001_Assembly_Assembly.root")'
@@ -170,7 +170,7 @@ Load REST Libraries:
 11.Xrays:
   stage: Run Examples
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - source ${CI_PROJECT_DIR}/install/thisREST.sh
     - cd ${CI_PROJECT_DIR}/install/examples/restG4/11.Xrays/
     - restG4 xrays.rml
     - restManager --c analysis.rml --f RestG4_xrays_00001_ArgonISO.root

--- a/examples/01.NLDBD/NLDBD.rml
+++ b/examples/01.NLDBD/NLDBD.rml
@@ -86,24 +86,24 @@ By default REST units are mm, keV and degrees
 
         // Use only one EM physics list
         <!-- EM Physics lists -->
-        <physicsList name="G4EmLivermorePhysics"></physicsList>
-        <!-- <physicsList name="G4EmPenelopePhysics"> </physicsList> -->
-        <!-- <physicsList name="G4EmStandardPhysics_option3"> </physicsList> -->
+        <physicsList name="G4EmLivermorePhysics"> <!-- "G4EmPenelopePhysics", "G4EmStandardPhysics_option3" -->
+            <option name="pixe" value="true"/>
+        </physicsList>
 
         <!-- Decay physics lists -->
-        <physicsList name="G4DecayPhysics"></physicsList>
-        <physicsList name="G4RadioactiveDecayPhysics"></physicsList>
+        <physicsList name="G4DecayPhysics"/>
+        <physicsList name="G4RadioactiveDecayPhysics"/>
         <physicsList name="G4RadioactiveDecay">
             <option name="ICM" value="true"/>
             <option name="ARM" value="true"/>
         </physicsList>
 
         <!-- Hadron physics lists -->
-        <physicsList name="G4HadronElasticPhysicsHP"></physicsList>
-        <physicsList name="G4IonBinaryCascadePhysics"></physicsList>
-        <physicsList name="G4HadronPhysicsQGSP_BIC_HP"></physicsList>
-        <physicsList name="G4NeutronTrackingCut"></physicsList>
-        <physicsList name="G4EmExtraPhysics"></physicsList>
+        <physicsList name="G4HadronElasticPhysicsHP"/>
+        <physicsList name="G4IonBinaryCascadePhysics"/>
+        <physicsList name="G4HadronPhysicsQGSP_BIC_HP"/>
+        <physicsList name="G4NeutronTrackingCut"/>
+        <physicsList name="G4EmExtraPhysics"/>
 
     </TRestGeant4PhysicsLists>
 

--- a/examples/01.NLDBD/NLDBD.rml
+++ b/examples/01.NLDBD/NLDBD.rml
@@ -84,7 +84,6 @@ By default REST units are mm, keV and degrees
         <parameter name="minEnergyRangeProductionCuts" value="1" units="keV"/>
         <parameter name="maxEnergyRangeProductionCuts" value="1" units="GeV"/>
 
-        // Use only one EM physics list
         <!-- EM Physics lists -->
         <physicsList name="G4EmLivermorePhysics"> <!-- "G4EmPenelopePhysics", "G4EmStandardPhysics_option3" -->
             <option name="pixe" value="true"/>

--- a/examples/04.MuonScan/Muon.rml
+++ b/examples/04.MuonScan/Muon.rml
@@ -48,9 +48,9 @@
         <parameter name="maxEnergyRangeProductionCuts" value="1" units="GeV"/>
 
         <!-- EM Physics lists -->
-        <physicsList name="G4EmLivermorePhysics"/>
-        <!-- <physicsList name="G4EmPenelopePhysics"> </physicsList> -->
-        <!-- <physicsList name="G4EmStandardPhysics_option3"> </physicsList> -->
+        <physicsList name="G4EmLivermorePhysics"> <!-- "G4EmPenelopePhysics", "G4EmStandardPhysics_option3" -->
+            <option name="pixe" value="true"/>
+        </physicsList>
 
         <!-- Decay physics lists -->
         <physicsList name="G4DecayPhysics"/>

--- a/examples/05.PandaXIII/Xe136bb0n.rml
+++ b/examples/05.PandaXIII/Xe136bb0n.rml
@@ -30,8 +30,7 @@
         <parameter name="seed" value="1"/>
 
         <generator type="volume" from="Gas">
-            <source use="Xe136bb0n.dat">
-            </source>
+            <source use="Xe136bb0n.dat"/>
         </generator>
 
         <storage sensitiveVolume="Gas">
@@ -53,24 +52,24 @@
         <parameter name="maxEnergyRangeProductionCuts" value="1GeV"/>
 
         <!-- EM Physics lists -->
-        <physicsList name="G4EmLivermorePhysics"></physicsList>
-        <!-- <physicsList name="G4EmPenelopePhysics"> </physicsList> -->
-        <!-- <physicsList name="G4EmStandardPhysics_option3"> </physicsList> -->
+        <physicsList name="G4EmLivermorePhysics"> <!-- "G4EmPenelopePhysics", "G4EmStandardPhysics_option3" -->
+            <option name="pixe" value="true"/>
+        </physicsList>
 
         <!-- Decay physics lists -->
-        <physicsList name="G4DecayPhysics"></physicsList>
-        <physicsList name="G4RadioactiveDecayPhysics"></physicsList>
+        <physicsList name="G4DecayPhysics"/>
+        <physicsList name="G4RadioactiveDecayPhysics"/>
         <physicsList name="G4RadioactiveDecay">
             <option name="ICM" value="true"/>
             <option name="ARM" value="true"/>
         </physicsList>
 
         <!-- Hadron physics lists -->
-        <physicsList name="G4HadronElasticPhysicsHP"></physicsList>
-        <physicsList name="G4IonBinaryCascadePhysics"></physicsList>
-        <physicsList name="G4HadronPhysicsQGSP_BIC_HP"></physicsList>
-        <physicsList name="G4NeutronTrackingCut"></physicsList>
-        <physicsList name="G4EmExtraPhysics"></physicsList>
+        <physicsList name="G4HadronElasticPhysicsHP"/>
+        <physicsList name="G4IonBinaryCascadePhysics"/>
+        <physicsList name="G4HadronPhysicsQGSP_BIC_HP"/>
+        <physicsList name="G4NeutronTrackingCut"/>
+        <physicsList name="G4EmExtraPhysics"/>
 
     </TRestGeant4PhysicsLists>
 

--- a/examples/08.Alphas/alphas.rml
+++ b/examples/08.Alphas/alphas.rml
@@ -64,11 +64,10 @@ By default REST units are mm, keV and degrees
         <parameter name="minEnergyRangeProductionCuts" value="1" units="keV"/>
         <parameter name="maxEnergyRangeProductionCuts" value="1" units="GeV"/>
 
-        // Use only one EM physics list
         <!-- EM Physics lists -->
-        <!-- <physicsList name="G4EmLivermorePhysics"> </physicsList> -->
-        <!-- <physicsList name="G4EmPenelopePhysics"> </physicsList> -->
-        <physicsList name="G4EmStandardPhysics_option4"/>
+        <physicsList name="G4EmStandardPhysics_option4"> <!-- "G4EmPenelopePhysics", "G4EmStandardPhysics_option3" -->
+            <option name="pixe" value="true"/>
+        </physicsList>
 
         <!-- Decay physics lists -->
         <physicsList name="G4DecayPhysics"/>

--- a/include/PhysicsList.h
+++ b/include/PhysicsList.h
@@ -8,8 +8,6 @@
 #include <G4VModularPhysicsList.hh>
 #include <globals.hh>
 
-class G4VPhysicsConstructor;
-
 class PhysicsList : public G4VModularPhysicsList {
    public:
     PhysicsList();
@@ -19,19 +17,22 @@ class PhysicsList : public G4VModularPhysicsList {
    protected:
     // Construct particle and physics
     virtual void InitializePhysicsLists();
-    virtual void ConstructParticle();
-    virtual void ConstructProcess();
-    virtual void SetCuts();
+
+    void ConstructParticle() override;
+    void ConstructProcess() override;
+    void SetCuts() override;
 
    private:
     G4EmConfigurator fEmConfig;
 
-    G4VPhysicsConstructor* fEmPhysicsList;
-    G4VPhysicsConstructor* fDecPhysicsList;
-    G4VPhysicsConstructor* fRadDecPhysicsList;
+    G4VPhysicsConstructor* fEmPhysicsList = nullptr;
+    std::string fEmPhysicsListName;  // Can be different from the output of GetPhysicsName
+
+    G4VPhysicsConstructor* fDecPhysicsList = nullptr;
+    G4VPhysicsConstructor* fRadDecPhysicsList = nullptr;
     std::vector<G4VPhysicsConstructor*> fHadronPhys;
 
-    TRestGeant4PhysicsLists* restPhysList;
+    TRestGeant4PhysicsLists* fRestPhysicsLists = nullptr;
 };
 
 #endif

--- a/include/PhysicsList.h
+++ b/include/PhysicsList.h
@@ -10,9 +10,9 @@
 
 class PhysicsList : public G4VModularPhysicsList {
    public:
-    PhysicsList();
-    PhysicsList(TRestGeant4PhysicsLists* restPhysicsLists);
-    ~PhysicsList();
+    PhysicsList() = delete;
+    explicit PhysicsList(TRestGeant4PhysicsLists* restPhysicsLists);
+    ~PhysicsList() override;
 
    protected:
     // Construct particle and physics

--- a/src/Application.cxx
+++ b/src/Application.cxx
@@ -113,6 +113,7 @@ void Application::Run(const CommandLineParameters& commandLineParameters) {
 
     fSimulationManager->fRestRun->AddMetadata(fSimulationManager->fRestGeant4Metadata);
     fSimulationManager->fRestRun->AddMetadata(fSimulationManager->fRestGeant4PhysicsLists);
+
     fSimulationManager->fRestRun->PrintMetadata();
 
     fSimulationManager->fRestRun->FormOutputFile();
@@ -138,6 +139,7 @@ void Application::Run(const CommandLineParameters& commandLineParameters) {
 
     runManager->SetUserInitialization(detector);
     runManager->SetUserInitialization(new PhysicsList(fSimulationManager->fRestGeant4PhysicsLists));
+    fSimulationManager->fRestGeant4PhysicsLists->PrintMetadata();
 
     runManager->SetUserInitialization(new ActionInitialization(fSimulationManager));
 

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -41,10 +41,6 @@
 
 using namespace std;
 
-PhysicsList::PhysicsList() : G4VModularPhysicsList() {
-    cout << "restG4. PhysicsList. Wrong constructor!!" << endl;
-}
-
 PhysicsList::PhysicsList(TRestGeant4PhysicsLists* physicsLists) : G4VModularPhysicsList() {
     // add new units for radioActive decays
     const G4double minute = 60 * second;
@@ -132,13 +128,11 @@ void PhysicsList::InitializePhysicsLists() {
 
     if (fRestPhysicsLists->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Essential &&
         emCounter == 0) {
-        G4cout << "REST WARNING : No electromagenetic physics list has been enabled!!" << G4endl;
+        RESTWarning << "PhysicsList: No EM physics list has been enabled" << RESTendl;
     }
 
     if (emCounter > 1) {
-        G4cout << "REST ERROR: restG4. PhysicsList. More than 1 EM PhysicsList "
-                  "enabled."
-               << G4endl;
+        cerr << "PhysicsList: More than 1 EM PhysicsList enabled." << endl;
         exit(1);
     }
 
@@ -250,29 +244,21 @@ void PhysicsList::ConstructProcess() {
         // Setting Internal Conversion (ICM) option.
         if (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "ICM") == "true") {
             radioactiveDecay->SetICM(true);
-        }  // Internal Conversion
-        else if (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "ICM") == "false") {
+        } else if (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "ICM") == "false") {
             radioactiveDecay->SetICM(false);
-        }  // Internal Conversion
-        else if (fRestPhysicsLists->GetVerboseLevel() >=
-                 TRestStringOutput::REST_Verbose_Level::REST_Essential) {
-            G4cout << "REST WARNING. restG4. PhysicsList. G4RadioactiveDecay. Option "
-                      "ICM not defined."
-                   << G4endl;
+        } else if (fRestPhysicsLists->GetVerboseLevel() >=
+                   TRestStringOutput::REST_Verbose_Level::REST_Essential) {
+            RESTWarning << "PhysicsList 'G4RadioactiveDecay' option 'ICM' not defined" << RESTendl;
         }
 
         // Enabling electron re-arrangement (ARM) option.
         if (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "ARM") == "true") {
             radioactiveDecay->SetARM(true);
-        }  // Internal Conversion
-        else if (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "ARM") == "false") {
+        } else if (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "ARM") == "false") {
             radioactiveDecay->SetARM(false);
-        }  // Internal Conversion
-        else if (fRestPhysicsLists->GetVerboseLevel() >=
-                 TRestStringOutput::REST_Verbose_Level::REST_Essential) {
-            G4cout << "REST WARNING. restG4. PhysicsList. G4RadioactiveDecay. Option "
-                      "ARM not defined."
-                   << G4endl;
+        } else if (fRestPhysicsLists->GetVerboseLevel() >=
+                   TRestStringOutput::REST_Verbose_Level::REST_Essential) {
+            RESTWarning << "PhysicsList 'G4RadioactiveDecay' option 'ARM' not defined" << RESTendl;
         }
     }
 


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Medium: 135](https://badgen.net/badge/PR%20Size/Medium%3A%20135/orange) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-physics-low-energy/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-physics-low-energy) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-physics-low-energy/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-physics-low-energy) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-physics-low-energy/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-physics-low-energy) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-physics-low-energy)](https://github.com/rest-for-physics/restG4/commits/lobis-physics-low-energy)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- https://github.com/rest-for-physics/geant4lib/pull/60

This PR fixes the following bug: physics lists options were not being read. Options such as "ARM" of DecayPhysics were not working.

Updates to low energy physics: Previously some options were enabled by default:

```
UI->ApplyCommand("/process/em/fluo true");
UI->ApplyCommand("/process/em/auger true");
UI->ApplyCommand("/process/em/pixe true");
```

I found out the option `pixe` is responsible for a significant increase of simulation time in latest versions of Geant4, due to a lot of very low energy e- being produced. (this is the cause why the 08.Alphas example runs so slow in the pipeline).

The changes in this PR make possible for the user to specify these 3 options as options in the EM physics list. For example:

```
<physicsList name="G4EmStandardPhysics_option4">
    <option name="pixe" value="true"/>
    <option name="auger" value="false"/>
    <option name="fluo" value="false"/>
</physicsList>
```

The default value for options `fluo` and `auger` is left as `true`, so the behaviour is the same as previously if not changed. However the option `pixe` new default value is `false`, in order to reduce simulation time.

I have modified examples to explictly enabled `pixe` in order not to modify the validation scripts, however they will be mofied in the future in order to speed them up.