### PR TITLE
Improve example running time

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
-    needs: [ check-installation, restG4-examples-01 ]
+    needs: [ check-installation ]
     steps:
       - uses: actions/checkout@v3
       - name: Restore cache

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Simulation results are determined by the random seed and the number of threads, 
 with the same seed will produce different results. Using the same seed and same number of threads produces the same
 results.
 
-The multithreading implementation of `restG4` is new and although it looks to work properly it may have some bugs. If
+The multithreading implementation of `restG4` is new and although it looks to be working properly it may have some bugs. If
 you find one of such bugs, please post an issue [here](https://github.com/rest-for-physics/restG4/issues) with
 the `multithreading` label.
 
@@ -49,13 +49,13 @@ The simulation run will naturally end when the selected number of events have be
 specified in the RML file or via the `-n` flag on the CLI. However, the user can also specify additional conditions to
 end the simulation early.
 
-- `restG4 simulation.rml -N 1000` will signal the simulation to stop once 1000 events have been marked as valid (saved
+- `restG4 simulation.rml -e 1000` will signal the simulation to stop once 1000 events have been marked as valid (saved
   on the output file). The final simulation will probably have a slightly higher number of entries than the value
   specified in the case of multithreading as the worker threads may still be working on valid events, or they may not
   have been saved yet. The number of processed events (the equivalent of `nEvents`) will be adjusted to the real number
   of processed events, overriding the selected value of the user, so the resulting simulation would be equivalent to a
   plain simulation using this value as `nEvents`. This holds more accurately the large the `-N` parameter.
-- `restG4 simulation.rml -S 1h20m30s` will signal the simulation to stop after 1 hour 20 minutes and 30 seconds have
+- `restG4 simulation.rml --time 1h20m30s` will signal the simulation to stop after 1 hour 20 minutes and 30 seconds have
   elapsed since the start. You can specify any value using this format such as `1h15m`, `30s`, etc.
 - Sending the interrupt signal (typically via `CTRL+C`) will signal the simulation to stop, and it will attempt to save
   the results into disk before closing the process.

--- a/examples/04.MuonScan/Muon.rml
+++ b/examples/04.MuonScan/Muon.rml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <restG4>
-
     <TRestRun name="MuonRun" title="A basic muon test with 2 active volumes">
         <parameter name="experimentName" value="MuonScan"/>
         <parameter name="readOnly" value="false"/>
@@ -12,46 +10,37 @@
         <parameter name="overwrite" value="off"/>
         <parameter name="outputFileName" value="Run[fRunNumber]_[fRunType]_[fRunTag]_[fRunUser].root"/>
     </TRestRun>
-
     <TRestGeant4Metadata name="restG4 run" title="MuonsFromPoint" verboseLevel="info">
         <parameter name="gdmlFile" value="setup.gdml"/>
         <parameter name="subEventTimeDelay" value="100us"/>
-
         <parameter name="nEvents" value="1000"/>
         <parameter name="saveAllEvents" value="off"/>
-
         <parameter name="seed" value="17021981"/>
-
         <generator type="point" position="(0,0,-50)cm">
             <source particle="mu-" excitedLevel="0.0">
                 <energy type="mono" energy="100GeV"/>
                 <angular type="flux" direction="(0,0,1)"/>
             </source>
         </generator>
-
         <detector>
             <parameter name="energyRange" value="(0,10)" units="GeV"/>
             <volume name="det_dw_01" sensitive="true" maxStepSize="1mm"/>
             <volume name="det_up_01" maxStepSize="1mm"/>
         </detector>
-
     </TRestGeant4Metadata>
-
     <TRestGeant4PhysicsLists name="default" title="First physics list implementation." verboseLevel="warning">
         <parameter name="cutForGamma" value="1" units="um"/>
         <parameter name="cutForElectron" value="1" units="um"/>
         <parameter name="cutForPositron" value="1" units="um"/>
-
         <parameter name="cutForMuon" value="1" units="mm"/>
         <parameter name="cutForNeutron" value="1" units="mm"/>
         <parameter name="minEnergyRangeProductionCuts" value="1" units="keV"/>
         <parameter name="maxEnergyRangeProductionCuts" value="1" units="GeV"/>
-
         <!-- EM Physics lists -->
-        <physicsList name="G4EmLivermorePhysics"> <!-- "G4EmPenelopePhysics", "G4EmStandardPhysics_option3" -->
-            <option name="pixe" value="true"/>
+        <physicsList name="G4EmLivermorePhysics">
+            <!-- "G4EmPenelopePhysics", "G4EmStandardPhysics_option3" -->
+            <option name="pixe" value="false"/>
         </physicsList>
-
         <!-- Decay physics lists -->
         <physicsList name="G4DecayPhysics"/>
         <physicsList name="G4RadioactiveDecayPhysics"/>
@@ -59,13 +48,10 @@
             <option name="ICM" value="true"/>
             <option name="ARM" value="true"/>
         </physicsList>
-
         <!-- Hadron physics lists -->
         <physicsList name="G4HadronElasticPhysicsHP"/>
         <physicsList name="G4IonBinaryCascadePhysics"/>
         <physicsList name="G4HadronPhysicsQGSP_BIC_HP"/>
         <physicsList name="G4EmExtraPhysics"/>
-
     </TRestGeant4PhysicsLists>
-
 </restG4>

--- a/examples/04.MuonScan/Validate.C
+++ b/examples/04.MuonScan/Validate.C
@@ -56,22 +56,22 @@ Int_t Validate(const char* filename) {
     double nEvents = run.GetEntries();
 
     double averageTotalEnergy = 0;
-    constexpr double averageTotalEnergyRef = 18.8645;
+    constexpr double averageTotalEnergyRef = 18.1009;
 
     double averageSensitiveEnergy = 0;
-    constexpr double averageSensitiveEnergyRef = 9.01081;
+    constexpr double averageSensitiveEnergyRef = 8.68937;
 
     double averageNumberOfTracks = 0;
-    constexpr double averageNumberOfTracksRef = 1388.56;
+    constexpr double averageNumberOfTracksRef = 425.292;
 
     double averageNumberOfHitsVolume0 = 0;
-    constexpr double averageNumberOfHitsVolume0Ref = 74.095;
+    constexpr double averageNumberOfHitsVolume0Ref = 68.674;
 
     double averageNumberOfHitsVolume1 = 0;
-    constexpr double averageNumberOfHitsVolume1Ref = 64.182;
+    constexpr double averageNumberOfHitsVolume1Ref = 58.278;
 
     TVector3 averagePosition = {};
-    const TVector3 averagePositionRef = {0.100946, -0.26358, 300.348};
+    const TVector3 averagePositionRef = {-0.00970671, 0.148902, 300.517};
 
     constexpr double tolerance = 0.001;
 

--- a/examples/08.Alphas/Validate.C
+++ b/examples/08.Alphas/Validate.C
@@ -15,7 +15,7 @@ Int_t Validate() {
     run.GetEntry(100);
 
     Double_t thetaSample = analysisTree->GetObservableValue<Double_t>("g4Ana_thetaPrimary");
-    constexpr Double_t thetaSampleRef = 1.77307;
+    constexpr Double_t thetaSampleRef = 2.85884;
 
     Double_t phiSample = analysisTree->GetObservableValue<Double_t>("g4Ana_phiPrimary");
     constexpr Double_t phiSampleRef = -1.59582;
@@ -24,24 +24,24 @@ Int_t Validate() {
     constexpr Double_t thetaAverageRef = 1.5767;
 
     Double_t phiAverage = analysisTree->GetObservableAverage("g4Ana_phiPrimary");
-    constexpr Double_t phiAverageRef = 0.0727066;
+    constexpr Double_t phiAverageRef = 0.069711;
 
     cout << "entry 100, theta: " << thetaSample << ", phi: " << phiSample << endl;
     cout << "average theta: " << thetaAverage << ", average phi: " << phiAverage << endl;
 
-    if (h1->Integral() != 1960) {
+    if (h1->Integral() != 1989) {
         cout << "Wrong number of alphas produced at 1MeV_5um!" << endl;
         cout << "Histogram contains : " << h1->Integral() << endl;
         return 10;
     }
 
-    if (h2->Integral() != 7623) {
+    if (h2->Integral() != 7422) {
         cout << "Wrong number of alphas produced at 5MeV_5um!" << endl;
         cout << "Histogram contains : " << h2->Integral() << endl;
         return 20;
     }
 
-    if (h3->Integral() != 9554) {
+    if (h3->Integral() != 9417) {
         cout << "Wrong number of alphas produced at 5MeV_1um!" << endl;
         cout << "Histogram contains : " << h3->Integral() << endl;
         return 30;

--- a/examples/08.Alphas/alphas.rml
+++ b/examples/08.Alphas/alphas.rml
@@ -1,21 +1,16 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Constructing XML-like REST metadata input file
      File : config.rml
      First concept author J. Galan (26-Apr-2015)
  -->
-
 <!-- 
 By default REST units are mm, keV and degrees
 -->
-
 <restG4>
-
     <globals>
         <parameter name="mainDataPath" value=""/>
         <parameter name="verboseLevel" value="essential"/>
     </globals>
-
     <TRestRun name="Run metadata" title="REST Metadata run info (template)">
         <parameter name="experimentName" value="Alphas"/>
         <parameter name="runType" value="simulation"/>
@@ -27,49 +22,36 @@ By default REST units are mm, keV and degrees
         <parameter name="overwrite" value="off"/>
         <parameter name="readOnly" value="false"/>
     </TRestRun>
-
     <TRestGeant4Metadata name="alphas" title="Alphas">
-
         <parameter name="gdmlFile" value="geometry/setup.gdml"/>
         <parameter name="subEventTimeDelay" value="100" units="us"/>
-
         <parameter name="seed" value="17021981"/>
-
         <!-- The number of events to be simulated is now defined in TRestGeant4Metadata -->
         <parameter name="nEvents" value="10000"/>
         <parameter name="registerEmptyTracks" value="false"/>
         <parameter name="saveAllEvents" value="false"/>
-
         <generator type="volume" from="source">
             <source particle="alpha">
                 <angular type="isotropic"/>
                 <energy type="mono" energy="${REST_ENERGY}" units="MeV"/>
             </source>
         </generator>
-
         <detector>
             <parameter name="energyRange" value="(0,2*${REST_ENERGY})" units="MeV"/>
             <volume name="gas" sensitive="true" maxStepSize="0.5mm"/>
         </detector>
-
     </TRestGeant4Metadata>
-
     <TRestGeant4PhysicsLists name="default" title="First physics list implementation.">
-
         <parameter name="cutForGamma" value="0.01" units="mm"/>
         <parameter name="cutForElectron" value="2" units="mm"/>
         <parameter name="cutForPositron" value="1" units="mm"/>
-
         <parameter name="cutForMuon" value="1" units="mm"/>
         <parameter name="cutForNeutron" value="1" units="mm"/>
         <parameter name="minEnergyRangeProductionCuts" value="1" units="keV"/>
         <parameter name="maxEnergyRangeProductionCuts" value="1" units="GeV"/>
-
         <!-- EM Physics lists -->
-        <physicsList name="G4EmStandardPhysics_option4"> <!-- "G4EmPenelopePhysics", "G4EmStandardPhysics_option3" -->
-            <option name="pixe" value="true"/>
-        </physicsList>
-
+        <physicsList name="G4EmStandardPhysics_option4"/>
+        <!-- "G4EmPenelopePhysics", "G4EmStandardPhysics_option3" -->
         <!-- Decay physics lists -->
         <physicsList name="G4DecayPhysics"/>
         <physicsList name="G4RadioactiveDecayPhysics"/>
@@ -77,14 +59,11 @@ By default REST units are mm, keV and degrees
             <option name="ICM" value="true"/>
             <option name="ARM" value="true"/>
         </physicsList>
-
         <!-- Hadron physics lists -->
         <physicsList name="G4HadronElasticPhysicsHP"/>
         <physicsList name="G4IonBinaryCascadePhysics"/>
         <physicsList name="G4HadronPhysicsQGSP_BIC_HP"/>
         <physicsList name="G4NeutronTrackingCut"/>
         <physicsList name="G4EmExtraPhysics"/>
-
     </TRestGeant4PhysicsLists>
-
 </restG4>

--- a/src/Application.cxx
+++ b/src/Application.cxx
@@ -270,8 +270,6 @@ int interruptSignalHandler(const int, void* ptr) {
 constexpr const char* geometryName = "Geometry";
 
 void Application::Run(const CommandLineOptions::Options& options) {
-    signal(SIGINT, (void (*)(int))interruptSignalHandler);
-
     const auto originalDirectory = filesystem::current_path();
 
     cout << "Current working directory: " << originalDirectory << endl;
@@ -435,6 +433,8 @@ void Application::Run(const CommandLineOptions::Options& options) {
         exit(1);
     }
     gGeoManager->Write(geometryName, TObject::kOverwrite);
+
+    signal(SIGINT, (void (*)(int))interruptSignalHandler);  // Add custom signal handler before simulation
 
     cout << "Number of events: " << nEvents << endl;
     if (nEvents > 0)  // batch mode

--- a/src/RunAction.cxx
+++ b/src/RunAction.cxx
@@ -1,26 +1,22 @@
 
 #include "RunAction.h"
 
-#include <PrimaryGeneratorAction.h>
-#include <SteppingVerbose.h>
-#include <TRestGeant4Metadata.h>
 #include <TRestRun.h>
 
-#include <G4PhysicalConstants.hh>
 #include <G4Run.hh>
 #include <G4RunManager.hh>
-#include <G4SystemOfUnits.hh>
-#include <G4UnitsTable.hh>
 #include <iomanip>
 
+#include "PrimaryGeneratorAction.h"
 #include "SimulationManager.h"
+#include "SteppingVerbose.h"
 
 using namespace std;
 
 RunAction::RunAction(SimulationManager* simulationManager)
     : G4UserRunAction(), fSimulationManager(simulationManager) {}
 
-RunAction::~RunAction() {}
+RunAction::~RunAction() = default;
 
 void RunAction::BeginOfRunAction(const G4Run*) {
     if (G4Threading::IsMasterThread() || !G4Threading::IsMultithreadedApplication()) {
@@ -50,14 +46,5 @@ void RunAction::EndOfRunAction(const G4Run*) {
         G4cout << restRun->GetEntries() << " events stored out of " << metadata->GetNumberOfEvents()
                << " simulated events" << endl;
         G4cout << "=======================================================================" << endl;
-    }
-
-    // Sanity check
-    if (metadata->GetNumberOfRequestedEntries() == 0 && metadata->GetSimulationMaxTimeSeconds() == 0 &&
-        metadata->GetNumberOfEvents() != G4RunManager::GetRunManager()->GetNumberOfEventsToBeProcessed()) {
-        cerr << "FATAL ERROR: possible error when calculating number of processed events, please check "
-                "'RunAction::EndOfRunAction'"
-             << endl;
-        exit(1);
     }
 }


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 27](https://badgen.net/badge/PR%20Size/Ok%3A%2027/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-examples/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-examples) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-examples/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-examples) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-examples/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-examples) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-examples)](https://github.com/rest-for-physics/restG4/commits/lobis-examples)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I disabled the "pixe" option for the EM physics list, which causes too many secondary electrons to be generated which makes the example take too much time.

This should improve the running time significantly.

I updated the validation with the new values.