### PR TITLE
Updated example validation Geant4 version to 11.0.3

### DIFF
--- a/examples/04.MuonScan/Validate.C
+++ b/examples/04.MuonScan/Validate.C
@@ -56,26 +56,26 @@ Int_t Validate(const char* filename) {
     double nEvents = run.GetEntries();
 
     double averageTotalEnergy = 0;
-    constexpr double averageTotalEnergyRef = 18.1009;
+    constexpr double averageTotalEnergyRef = 18.074;
 
     double averageSensitiveEnergy = 0;
-    constexpr double averageSensitiveEnergyRef = 8.68937;
+    constexpr double averageSensitiveEnergyRef = 8.99048;
 
     double averageNumberOfTracks = 0;
-    constexpr double averageNumberOfTracksRef = 425.292;
+    constexpr double averageNumberOfTracksRef = 432.763;
 
     double averageNumberOfHitsVolume0 = 0;
-    constexpr double averageNumberOfHitsVolume0Ref = 68.674;
+    constexpr double averageNumberOfHitsVolume0Ref = 66.317;
 
     double averageNumberOfHitsVolume1 = 0;
-    constexpr double averageNumberOfHitsVolume1Ref = 58.278;
+    constexpr double averageNumberOfHitsVolume1Ref = 61.555;
 
     TVector3 averagePosition = {};
-    const TVector3 averagePositionRef = {-0.00970671, 0.148902, 300.517};
+    const TVector3 averagePositionRef = {-0.59902, 0.0256995, 300.385};
 
     constexpr double tolerance = 0.001;
 
-    for (size_t i = 0; i < run.GetEntries(); i++) {
+    for (Long64_t i = 0; i < run.GetEntries(); i++) {
         run.GetEntry(i);
 
         averageTotalEnergy += event->GetTotalDepositedEnergy() / nEvents;

--- a/examples/13.IAXO/Validate.C
+++ b/examples/13.IAXO/Validate.C
@@ -32,25 +32,25 @@ Int_t Validate(const char* filename) {
     TRestGeant4Event* event = run.GetInputEvent<TRestGeant4Event>();
     run.GetEntry(0);
 
-    if (event->GetNumberOfTracks() != 405) {
+    if (event->GetNumberOfTracks() != 45) {
         cout << "Incorrect number of tracks: " << event->GetNumberOfTracks() << endl;
         return 4;
     }
-    if (event->GetNumberOfHits() != 6345) {
+    if (event->GetNumberOfHits() != 1080) {
         cout << "Incorrect number of hits: " << event->GetNumberOfHits() << endl;
         return 5;
     }
 
-    constexpr Double_t sensitiveVolumeEnergyRef = 30.2461;
+    constexpr Double_t sensitiveVolumeEnergyRef = 10.345786;
     if (TMath::Abs(event->GetSensitiveVolumeEnergy() - sensitiveVolumeEnergyRef) > 1e-4) {
         cout << "Incorrect sensitive volume energy: " << event->GetSensitiveVolumeEnergy() << endl;
         return 6;
     }
 
     const auto scintillatorVolumeName =
-        "VetoSystem_vetoSystemWest_vetoLayerWest2_assembly-16.veto3_scintillatorVolume-1500.0mm-f1a5df6b";
+        "VetoSystem_vetoSystemBottom_vetoLayerBottom2_assembly-10.veto2_scintillatorVolume-1500.0mm-73266212";
     const auto scintillatorEnergy = event->GetEnergyInVolume(scintillatorVolumeName);
-    const auto scintillatorEnergyRef = 3367.0536;
+    const auto scintillatorEnergyRef = 1078.0490;
     if (TMath::Abs(scintillatorEnergy - scintillatorEnergyRef) > 1e-4) {
         cout << "Incorrect scintillator volume energy: " << scintillatorEnergy << endl;
         return 7;


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 12](https://badgen.net/badge/PR%20Size/Ok%3A%2012/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-geant4-11.0.3/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-geant4-11.0.3) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-geant4-11.0.3/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-geant4-11.0.3) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-geant4-11.0.3/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-geant4-11.0.3) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-geant4-11.0.3)](https://github.com/rest-for-physics/restG4/commits/lobis-geant4-11.0.3)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Update the validation macros with new reference values.