### PR TITLE
Added fix for tritium decay

### DIFF
--- a/include/PhysicsList.h
+++ b/include/PhysicsList.h
@@ -8,10 +8,12 @@
 #include <G4VModularPhysicsList.hh>
 #include <globals.hh>
 
+#include "SimulationManager.h"
+
 class PhysicsList : public G4VModularPhysicsList {
    public:
     PhysicsList() = delete;
-    explicit PhysicsList(TRestGeant4PhysicsLists* restPhysicsLists);
+    explicit PhysicsList(SimulationManager* simulationManager, TRestGeant4PhysicsLists* restPhysicsLists);
     ~PhysicsList() override;
 
    protected:
@@ -23,6 +25,8 @@ class PhysicsList : public G4VModularPhysicsList {
     void SetCuts() override;
 
    private:
+    SimulationManager* fSimulationManager = nullptr;
+
     G4EmConfigurator fEmConfig;
 
     G4VPhysicsConstructor* fEmPhysicsList = nullptr;

--- a/src/Application.cxx
+++ b/src/Application.cxx
@@ -402,7 +402,8 @@ void Application::Run(const CommandLineOptions::Options& options) {
     fSimulationManager.InitializeUserDistributions();
 
     runManager->SetUserInitialization(new DetectorConstruction(&fSimulationManager));
-    runManager->SetUserInitialization(new PhysicsList(fSimulationManager.GetRestPhysicsLists()));
+    runManager->SetUserInitialization(
+        new PhysicsList(&fSimulationManager, fSimulationManager.GetRestPhysicsLists()));
     fSimulationManager.GetRestPhysicsLists()->PrintMetadata();
     runManager->SetUserInitialization(new ActionInitialization(&fSimulationManager));
 

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -261,29 +261,31 @@ void PhysicsList::ConstructProcess() {
             RESTWarning << "PhysicsList 'G4RadioactiveDecay' option 'ARM' not defined" << RESTendl;
         }
 
-        // Tritium (H3) fix | https://geant4-forum.web.cern.ch/t/triton-decay-with-rdecay01-example/2616
-        // Make tritium unstable, so it can be decayed
-        G4ParticleDefinition* tritium = G4Triton::Definition();
-        tritium->SetPDGStable(false);
+        if (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "TritiumDecay", "false") ==
+            "true") {
+            // Tritium (H3) fix | https://geant4-forum.web.cern.ch/t/triton-decay-with-rdecay01-example/2616
+            G4ParticleDefinition* tritium = G4Triton::Definition();
+            tritium->SetPDGStable(false);
 
-        // Remove G4Decay process, which requires a registered decay table
-        G4VProcess* decay = nullptr;
-        G4ProcessManager* tritiumProcessManager = tritium->GetProcessManager();
-        G4ProcessVector* tritiumProcessVector = tritiumProcessManager->GetAtRestProcessVector();
-        for (int i = 0; i < tritiumProcessVector->size() && decay == nullptr; i++) {
-            if ((*tritiumProcessVector)[i]->GetProcessName() == "Decay") decay = (*tritiumProcessVector)[i];
-        }
-        if (decay) {
-            tritiumProcessManager->RemoveProcess(decay);
-        }
+            G4VProcess* decay = nullptr;
+            G4ProcessManager* tritiumProcessManager = tritium->GetProcessManager();
+            G4ProcessVector* tritiumProcessVector = tritiumProcessManager->GetAtRestProcessVector();
+            for (int i = 0; i < tritiumProcessVector->size() && decay == nullptr; i++) {
+                if ((*tritiumProcessVector)[i]->GetProcessName() == "Decay")
+                    decay = (*tritiumProcessVector)[i];
+            }
+            if (decay) {
+                tritiumProcessManager->RemoveProcess(decay);
+            }
 
 #ifdef GEANT4_VERSION_LESS_11_0_0
-        decay = new G4RadioactiveDecayBase();
+            decay = new G4RadioactiveDecayBase();
 #else
-        decay = new G4RadioactiveDecay();
+            decay = new G4RadioactiveDecay();
 #endif
 
-        tritium->GetProcessManager()->AddProcess(decay, 1000, -1, 1000);
+            tritium->GetProcessManager()->AddProcess(decay, 1000, -1, 1000);
+        }
     }
 
     auto theParticleIterator = GetParticleIterator();

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -262,6 +262,7 @@ void PhysicsList::ConstructProcess() {
             RESTWarning << "PhysicsList 'G4RadioactiveDecay' option 'ARM' not defined" << RESTendl;
         }
 
+#ifndef GEANT4_VERSION_LESS_11_0_0
         /*
          * If no TritiumDecay is set, do not produce tritium decay unless particle source is H3
          * If H3 is particle source, produce tritium decay unless TritiumDecay option is explicitly disabled
@@ -286,14 +287,11 @@ void PhysicsList::ConstructProcess() {
                 tritiumProcessManager->RemoveProcess(decay);
             }
 
-#ifdef GEANT4_VERSION_LESS_11_0_0
-            decay = new G4RadioactiveDecayBase();
-#else
             decay = new G4RadioactiveDecay();
-#endif
 
             tritium->GetProcessManager()->AddProcess(decay, 1000, -1, 1000);
         }
+#endif
     }
 
     auto theParticleIterator = GetParticleIterator();

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -41,7 +41,8 @@
 
 using namespace std;
 
-PhysicsList::PhysicsList(TRestGeant4PhysicsLists* physicsLists) : G4VModularPhysicsList() {
+PhysicsList::PhysicsList(SimulationManager* simulationManager, TRestGeant4PhysicsLists* physicsLists)
+    : G4VModularPhysicsList(), fSimulationManager(simulationManager) {
     // add new units for radioActive decays
     const G4double minute = 60 * second;
     const G4double hour = 60 * minute;
@@ -261,8 +262,15 @@ void PhysicsList::ConstructProcess() {
             RESTWarning << "PhysicsList 'G4RadioactiveDecay' option 'ARM' not defined" << RESTendl;
         }
 
-        if (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "TritiumDecay", "false") ==
-            "true") {
+        /*
+         * If no TritiumDecay is set, do not produce tritium decay unless particle source is H3
+         * If H3 is particle source, produce tritium decay unless TritiumDecay option is explicitly disabled
+         */
+        if (!(fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "TritiumDecay") ==
+              "false") &&
+            (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "TritiumDecay", "false") ==
+                 "true" ||
+             fSimulationManager->GetRestMetadata()->GetParticleSource()->GetParticleName() == "H3")) {
             // Tritium (H3) fix | https://geant4-forum.web.cern.ch/t/triton-decay-with-rdecay01-example/2616
             G4ParticleDefinition* tritium = G4Triton::Definition();
             tritium->SetPDGStable(false);

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -260,6 +260,30 @@ void PhysicsList::ConstructProcess() {
                    TRestStringOutput::REST_Verbose_Level::REST_Essential) {
             RESTWarning << "PhysicsList 'G4RadioactiveDecay' option 'ARM' not defined" << RESTendl;
         }
+
+        // Tritium (H3) fix | https://geant4-forum.web.cern.ch/t/triton-decay-with-rdecay01-example/2616
+        // Make tritium unstable, so it can be decayed
+        G4ParticleDefinition* tritium = G4Triton::Definition();
+        tritium->SetPDGStable(false);
+
+        // Remove G4Decay process, which requires a registered decay table
+        G4VProcess* decay = nullptr;
+        G4ProcessManager* tritiumProcessManager = tritium->GetProcessManager();
+        G4ProcessVector* tritiumProcessVector = tritiumProcessManager->GetAtRestProcessVector();
+        for (int i = 0; i < tritiumProcessVector->size() && decay == nullptr; i++) {
+            if ((*tritiumProcessVector)[i]->GetProcessName() == "Decay") decay = (*tritiumProcessVector)[i];
+        }
+        if (decay) {
+            tritiumProcessManager->RemoveProcess(decay);
+        }
+
+#ifdef GEANT4_VERSION_LESS_11_0_0
+        decay = new G4RadioactiveDecayBase();
+#else
+        decay = new G4RadioactiveDecay();
+#endif
+
+        tritium->GetProcessManager()->AddProcess(decay, 1000, -1, 1000);
     }
 
     auto theParticleIterator = GetParticleIterator();


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 40](https://badgen.net/badge/PR%20Size/Ok%3A%2040/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-decay/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-decay) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-decay/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-decay) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-decay/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-decay) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-decay)](https://github.com/rest-for-physics/restG4/commits/lobis-decay)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes https://github.com/rest-for-physics/restG4/issues/67

For more information about the solution read https://geant4-forum.web.cern.ch/t/triton-decay-with-rdecay01-example/2616.

Tritium decay can now be used via the following option on the physics list:

```
<physicsList name="G4RadioactiveDecay">
    <option name="TritiumDecay" value="false"/>
</physicsList>
```

If the primary particle source is `H3`, then this option is enabled by default. It can still be explicitly disabled. It is disabled by default for other primary particle sources.

I could not make it work for old Geant4 versions (namely the 10.4.3 reference version). It can probably by implemented if anyone wants to do the fix.