### PR TITLE
CLI can now parse scientific notation integers

### DIFF
--- a/src/Application.cxx
+++ b/src/Application.cxx
@@ -183,11 +183,19 @@ Options ProcessCommandLineOptions(int argc, char* const argv[]) {
                 exit(1);
             }
         } else if ((arg == "-n") || (arg == "--events")) {
-            if (i + 1 < argc) {  // Make sure we aren't at the end of argv!
-                options.nEvents =
-                    stoi(argv[++i]);  // Increment 'i' so we don't get the argument as the next argv[i].
+            if (i + 1 < argc) {        // Make sure we aren't at the end of argv!
+                string s = argv[++i];  // Increment 'i' so we don't get the argument as the next argv[i].
+                // Allows to parse inputs of the form 1E5, 1.5E10 etc.
+                regex rgx("^([0-9]+.?([0-9]+)?)E([0-9]+)");
+                std::smatch matches;
+                if (std::regex_search(s, matches, rgx)) {
+                    options.nEvents = int(stod(matches[1].str()) * TMath::Power(10, stoi(matches[3].str())));
+                } else {
+                    options.nEvents = stoi(s);
+                }
                 if (options.nEvents <= 0) {
-                    cout << "--events option error: number of events must be > 0" << endl;
+                    cout << "--events option error: number of events must be > 0 (input: " << s << ")"
+                         << endl;
                     exit(1);
                 }
             } else {

--- a/src/Application.cxx
+++ b/src/Application.cxx
@@ -124,6 +124,17 @@ int GetSecondsFromFullTimeExpression(const char* expression) {
     return seconds;
 }
 
+int GetNumberFromStringScientific(string& s) {
+    // Allows to parse inputs of the form 1E5, 1.5E10 etc.
+    regex rgx("^([0-9]+.?([0-9]+)?)E([0-9]+)");
+    std::smatch matches;
+    if (std::regex_search(s, matches, rgx)) {
+        return int(stod(matches[1].str()) * TMath::Power(10, stoi(matches[3].str())));
+    } else {
+        return stoi(s);
+    }
+}
+
 Options ProcessCommandLineOptions(int argc, char* const argv[]) {
     Options options;
     options.argc = argc;
@@ -185,14 +196,7 @@ Options ProcessCommandLineOptions(int argc, char* const argv[]) {
         } else if ((arg == "-n") || (arg == "--events")) {
             if (i + 1 < argc) {        // Make sure we aren't at the end of argv!
                 string s = argv[++i];  // Increment 'i' so we don't get the argument as the next argv[i].
-                // Allows to parse inputs of the form 1E5, 1.5E10 etc.
-                regex rgx("^([0-9]+.?([0-9]+)?)E([0-9]+)");
-                std::smatch matches;
-                if (std::regex_search(s, matches, rgx)) {
-                    options.nEvents = int(stod(matches[1].str()) * TMath::Power(10, stoi(matches[3].str())));
-                } else {
-                    options.nEvents = stoi(s);
-                }
+                options.nEvents = GetNumberFromStringScientific(s);
                 if (options.nEvents <= 0) {
                     cout << "--events option error: number of events must be > 0 (input: " << s << ")"
                          << endl;
@@ -203,9 +207,9 @@ Options ProcessCommandLineOptions(int argc, char* const argv[]) {
                 exit(1);
             }
         } else if ((arg == "-e") || (arg == "--entries")) {
-            if (i + 1 < argc) {  // Make sure we aren't at the end of argv!
-                options.nRequestedEntries =
-                    stoi(argv[++i]);  // Increment 'i' so we don't get the argument as the next argv[i].
+            if (i + 1 < argc) {        // Make sure we aren't at the end of argv!
+                string s = argv[++i];  // Increment 'i' so we don't get the argument as the next argv[i].
+                options.nRequestedEntries = GetNumberFromStringScientific(s);
                 if (options.nRequestedEntries <= 0) {
                     cout << "--entries option error: number of entries must be > 0" << endl;
                     exit(1);

--- a/src/Application.cxx
+++ b/src/Application.cxx
@@ -12,6 +12,7 @@
 #include <TRestRun.h>
 
 #include <csignal>
+#include <regex>
 #ifndef GEANT4_WITHOUT_G4RunManagerFactory
 #include <G4RunManagerFactory.hh>
 #endif


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 20](https://badgen.net/badge/PR%20Size/Ok%3A%2020/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-cli/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-cli) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-cli/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-cli) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-cli/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-cli) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-cli)](https://github.com/rest-for-physics/restG4/commits/lobis-cli)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now you can pass values such as `-n 1E5` etc to the CLI and it will be correctly interpreted. It is supported both for the `-n` and `-e` option.