### PR TITLE
Implement `kill` option for volumes

### DIFF
--- a/src/DataModel.cxx
+++ b/src/DataModel.cxx
@@ -153,6 +153,8 @@ void TRestGeant4Hits::InsertStep(const G4Step* step) {
     const auto& volumeNameGeant4 = step->GetPreStepPoint()->GetPhysicalVolume()->GetName();
     const auto& volumeName = geometryInfo.GetAlternativeNameFromGeant4PhysicalName(volumeNameGeant4);
 
+    const bool kill = metadata->IsKillVolume(volumeName);
+
     if (!metadata->IsActiveVolume(volumeName) && step->GetTrack()->GetCurrentStepNumber() != 0) {
         // we always store the first step
         return;
@@ -161,6 +163,8 @@ void TRestGeant4Hits::InsertStep(const G4Step* step) {
     const auto& particle = step->GetTrack()->GetDefinition();
     const auto& particleID = particle->GetPDGEncoding();
     const auto& particleName = particle->GetParticleName();
+
+    auto energy = step->GetTotalEnergyDeposit() / CLHEP::keV;
 
     metadata->fGeant4PhysicsInfo.InsertParticleName(particleID, particleName);
 
@@ -175,9 +179,17 @@ void TRestGeant4Hits::InsertStep(const G4Step* step) {
         processID = TRestGeant4PhysicsInfo::GetProcessIDFromGeant4Process(process);
     }
 
+    if (kill) {
+        processName = "REST-for-physics-kill";
+        processTypeName = "REST-for-physics";
+        processID = 1000000;  // use id out of range!
+        energy = 0;
+
+        step->GetTrack()->SetTrackStatus(fStopAndKill);
+    }
+
     metadata->fGeant4PhysicsInfo.InsertProcessName(processID, processName, processTypeName);
 
-    const auto energy = step->GetTotalEnergyDeposit() / CLHEP::keV;
     const auto trackKineticEnergy = step->GetTrack()->GetKineticEnergy() / CLHEP::keV;
 
     auto sensitiveVolumeName =
@@ -230,7 +242,7 @@ void OutputManager::RemoveUnwantedTracks() {
             }
         }
     }
-    const size_t numberOfTracksBefore = fEvent->fTracks.size();
+    // const size_t numberOfTracksBefore = fEvent->fTracks.size();
 
     vector<TRestGeant4Track> tracksAfterRemoval;
     for (const auto& track : fEvent->fTracks) {


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 14](https://badgen.net/badge/PR%20Size/Ok%3A%2014/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-kill-volume/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-kill-volume) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-kill-volume/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-kill-volume) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-kill-volume/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-kill-volume) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-kill-volume)](https://github.com/rest-for-physics/restG4/commits/lobis-kill-volume)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Needs https://github.com/rest-for-physics/geant4lib/pull/70.

The kill option (boolean) has been added to volumes defined in detector section.

```
<volume name="volume" kill="true" />
```

When enabled the track will be killed upon entering the volume (or more generally in the first hit on the volume). The hit will be recorded with zero energy but the position time and momentum will be recorded. A new process called REST-for-Physics-kill is mocked in the stepping action to keep track of this.

- [x] ClassDef version number should be increased for `TRestGeant4Metadata`.
- [x] `TRestGeant4Metadata`: new kill feature should be documented.