### PR TITLE
Update progress printing logic

### DIFF
--- a/src/EventAction.cxx
+++ b/src/EventAction.cxx
@@ -34,8 +34,8 @@ void EventAction::BeginOfEventAction(const G4Event* event) {
     else {
         const int numberOfEventsToBePercent =
             G4RunManager::GetRunManager()->GetNumberOfEventsToBeProcessed() / 100;
-        if ((restG4Metadata->PrintProgress() ||
-             restG4Metadata->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Essential) &&
+        if ((restG4Metadata->PrintProgress() &&
+             restG4Metadata->GetVerboseLevel() != TRestStringOutput::REST_Verbose_Level::REST_Silent) &&
             // print roughly every 1% of events or whenever 10 seconds without printing have elapsed
             (numberOfEventsToBePercent > 0 && (eventID + 1) % numberOfEventsToBePercent == 0)) {
             fSimulationManager->SyncStatsFromChild();


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-print-progress/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-print-progress) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-print-progress/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-print-progress) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-print-progress/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-print-progress) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-print-progress)](https://github.com/rest-for-physics/restG4/commits/lobis-print-progress)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The periodic message showing simulation progress will be printed by default, controlled by the `printProgress` `TRestGeant4Metadata` parameter. Now it won't be printed if the verbosity is "silent".

- https://github.com/rest-for-physics/geant4lib/pull/73