### PR TITLE
add active volumes to event to fix issue in restManager analysis

### DIFF
--- a/src/SimulationManager.cxx
+++ b/src/SimulationManager.cxx
@@ -241,6 +241,10 @@ void OutputManager::UpdateEvent() {
              << fEvent->GetID() << endl;
         exit(1);
     }
+
+    for (const TString& volumeName : fEvent->GetGeant4Metadata()->GetActiveVolumes()) {
+        fEvent->AddActiveVolume(volumeName.Data());
+    }
 }
 
 bool OutputManager::IsEmptyEvent() const { return !fEvent || fEvent->fTracks.empty(); }
@@ -265,6 +269,9 @@ bool OutputManager::IsValidEvent() const {
 
 void OutputManager::FinishAndSubmitEvent() {
     if (IsValidEvent()) {
+        for (int i = 0; i < fEvent->GetNumberOfActiveVolumes(); i++) {
+            fEvent->SetEnergyDepositedInVolume(i, fEvent->GetEnergyInVolume(fEvent->fVolumeStoredNames[i]));
+        }
         if (fSimulationManager->GetRestMetadata()->GetRemoveUnwantedTracks()) {
             RemoveUnwantedTracks();
         }


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 7](https://badgen.net/badge/PR%20Size/Ok%3A%207/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-energy-analaysis-issue/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-energy-analaysis-issue) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-energy-analaysis-issue/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-energy-analaysis-issue) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-energy-analaysis-issue/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-energy-analaysis-issue) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-energy-analaysis-issue)](https://github.com/rest-for-physics/restG4/commits/lobis-energy-analaysis-issue)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Active volumes are also added to `TRestGeant4Event`. This is very messy and should be revisited in the future.

Fixes https://github.com/rest-for-physics/geant4lib/issues/72. I checked and it seems to solve the problem, but it would be nice if somebody else checked before merging.