### PR TITLE
update print progress

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -4,13 +4,15 @@
 using namespace std;
 
 constexpr auto banner =
-    "                             #####  #       \n"
-    " #####  ######  ####  ##### #     # #    #  \n"
-    " #    # #      #        #   #       #    #  \n"
-    " #    # #####   ####    #   #  #### #    #  \n"
-    " #####  #           #   #   #     # ####### \n"
-    " #   #  #      #    #   #   #     #      #  \n"
-    " #    # ######  ####    #    #####       #  \n"
+    "\n"
+    "                         888     .d8888b.      d8888 \n"
+    "                         888    d88P  Y88b    d8P888 \n"
+    "                         888    888    888   d8P 888 \n"
+    "888d888 .d88b.  .d8888b  888888 888         d8P  888 \n"
+    "888P\"  d8P  Y8b 88K      888    888  88888 d88   888 \n"
+    "888    88888888 \"Y8888b. 888    888    888 8888888888\n"
+    "888    Y8b.          X88 Y88b.  Y88b  d88P       888 \n"
+    "888     \"Y8888   88888P'  \"Y888  \"Y8888P88       888 \n"
     "\n"
     "🔍 Source code: https://github.com/rest-for-physics/restG4\n"
     "🐞 Bug reports: https://github.com/rest-for-physics/restG4/issues\n";

--- a/src/Application.cxx
+++ b/src/Application.cxx
@@ -11,7 +11,6 @@
 #include <TRestGeant4PhysicsLists.h>
 #include <TRestRun.h>
 
-#include <csignal>
 #include <regex>
 #ifndef GEANT4_WITHOUT_G4RunManagerFactory
 #include <G4RunManagerFactory.hh>
@@ -272,14 +271,6 @@ Options ProcessCommandLineOptions(int argc, char* const argv[]) {
 
 }  // namespace CommandLineOptions
 
-int interruptSignalHandler(const int, void* ptr) {
-    // See https://stackoverflow.com/a/43400143/11776908
-    cout << "Stopping Run! Program was manually stopped by user (CTRL+C)!" << endl;
-    const auto manager = (SimulationManager*)(ptr);
-    manager->StopSimulation();
-    return 0;
-}
-
 constexpr const char* geometryName = "Geometry";
 
 void Application::Run(const CommandLineOptions::Options& options) {
@@ -447,8 +438,6 @@ void Application::Run(const CommandLineOptions::Options& options) {
         exit(1);
     }
     gGeoManager->Write(geometryName, TObject::kOverwrite);
-
-    signal(SIGINT, (void (*)(int))interruptSignalHandler);  // Add custom signal handler before simulation
 
     cout << "Number of events: " << nEvents << endl;
     if (nEvents > 0)  // batch mode

--- a/src/Application.cxx
+++ b/src/Application.cxx
@@ -198,8 +198,8 @@ Options ProcessCommandLineOptions(int argc, char* const argv[]) {
                 string s = argv[++i];  // Increment 'i' so we don't get the argument as the next argv[i].
                 options.nEvents = GetNumberFromStringScientific(s);
                 if (options.nEvents <= 0) {
-                    cout << "--events option error: number of events must be > 0 (input: " << s << ")"
-                         << endl;
+                    cout << "--events option error: number of events must be > 0 (input: " << options.nEvents
+                         << " from " << s << ")" << endl;
                     exit(1);
                 }
             } else {
@@ -211,7 +211,8 @@ Options ProcessCommandLineOptions(int argc, char* const argv[]) {
                 string s = argv[++i];  // Increment 'i' so we don't get the argument as the next argv[i].
                 options.nRequestedEntries = GetNumberFromStringScientific(s);
                 if (options.nRequestedEntries <= 0) {
-                    cout << "--entries option error: number of entries must be > 0" << endl;
+                    cout << "--entries option error: number of entries must be > 0 (input: "
+                         << options.nRequestedEntries << " from " << s << ")" << endl;
                     exit(1);
                 }
             } else {

--- a/src/RunAction.cxx
+++ b/src/RunAction.cxx
@@ -20,10 +20,19 @@ RunAction::~RunAction() = default;
 
 void RunAction::BeginOfRunAction(const G4Run*) {
     if (G4Threading::IsMasterThread() || !G4Threading::IsMultithreadedApplication()) {
-        G4cout << "========================== Begin of Run Action ========================" << endl;
-        G4cout << G4RunManager::GetRunManager()->GetNumberOfEventsToBeProcessed() << " events to be simulated"
-               << endl;
-        G4cout << "=======================================================================" << endl;
+        G4cout << "========================== Begin of Run Action ========================" << G4endl;
+        G4cout << "Events to be simulated: "
+               << G4RunManager::GetRunManager()->GetNumberOfEventsToBeProcessed() << G4endl;
+        if (fSimulationManager->GetRestMetadata()->GetNumberOfRequestedEntries() > 0) {
+            G4cout << "Requested number of entries in file: "
+                   << fSimulationManager->GetRestMetadata()->GetNumberOfRequestedEntries() << G4endl;
+        }
+        if (fSimulationManager->GetRestMetadata()->GetSimulationMaxTimeSeconds() > 0) {
+            G4cout << "Maximum simulation time: "
+                   << ToTimeStringLong(fSimulationManager->GetRestMetadata()->GetSimulationMaxTimeSeconds())
+                   << G4endl;
+        }
+        G4cout << "=======================================================================" << G4endl;
     }
 
     fSimulationManager->BeginOfRunAction();

--- a/src/SimulationManager.cxx
+++ b/src/SimulationManager.cxx
@@ -38,20 +38,53 @@ void PeriodicPrint(SimulationManager* simulationManager) {
             simulationManager->SyncStatsFromChild(outputManager);
         }
 
-        G4cout << TString::Format("%5.2f", double(simulationManager->GetNumberOfProcessedEvents()) /
-                                               double(restG4Metadata->GetNumberOfEvents()) * 100)
-                      .Data()
-               << "% - " << simulationManager->GetNumberOfProcessedEvents() << " events processed out of "
-               << restG4Metadata->GetNumberOfEvents() << " requested events ("
-               << TString::Format("%.2e", simulationManager->GetNumberOfProcessedEvents() /
-                                              simulationManager->GetElapsedTime())
-                      .Data()
-               << " per second). " << simulationManager->GetNumberOfStoredEvents() << " events stored ("
+        string outputPercentageType = "events";
+        double completionPercentage = double(simulationManager->GetNumberOfProcessedEvents()) /
+                                      double(restG4Metadata->GetNumberOfEvents()) * 100;
+        if (restG4Metadata->GetNumberOfRequestedEntries() > 0) {
+            auto completionPercentageEntries = double(simulationManager->GetNumberOfStoredEvents()) /
+                                               double(restG4Metadata->GetNumberOfRequestedEntries()) * 100;
+            if (completionPercentageEntries > completionPercentage) {
+                completionPercentage = completionPercentageEntries;
+                outputPercentageType = "entries";
+            }
+        }
+        if (restG4Metadata->GetSimulationMaxTimeSeconds() > 0) {
+            auto completionPercentageTime = double(simulationManager->GetElapsedTime()) /
+                                            double(restG4Metadata->GetSimulationMaxTimeSeconds()) * 100;
+            if (completionPercentageTime > completionPercentage) {
+                completionPercentage = completionPercentageTime;
+                outputPercentageType = "time";
+            }
+        }
+        const string eventsProgress =
+            " | " + to_string(simulationManager->GetNumberOfProcessedEvents()) + " events processed / " +
+            to_string(restG4Metadata->GetNumberOfEvents()) + " requested (" +
+            TString::Format(
+                "%.2e", simulationManager->GetNumberOfProcessedEvents() / simulationManager->GetElapsedTime())
+                .Data() +
+            "/s)";
+        const string timeProgress =
+            " | " + ToTimeStringLong(simulationManager->GetElapsedTime()) + " elapsed / " +
+            ToTimeStringLong(simulationManager->GetRestMetadata()->GetSimulationMaxTimeSeconds());
+
+        string progress = "";
+        if (outputPercentageType == "events") {
+            progress = eventsProgress;
+        } else if (outputPercentageType == "time") {
+            progress = timeProgress;
+        }
+        string timeInfo = "";
+        if (outputPercentageType != "time") {
+            timeInfo = " | " + ToTimeStringLong(simulationManager->GetElapsedTime()) + " elapsed";
+        }
+        G4cout << TString::Format("%5.2f", completionPercentage).Data() << "% | "
+               << simulationManager->GetNumberOfStoredEvents() << " events stored / "
+               << simulationManager->GetNumberOfProcessedEvents() << " processed ("
                << TString::Format("%.2e", simulationManager->GetNumberOfStoredEvents() /
                                               simulationManager->GetElapsedTime())
                       .Data()
-               << " per second). " << ToTimeStringLong(simulationManager->GetElapsedTime()) << " elapsed"
-               << G4endl;
+               << "/s)" << progress << timeInfo << G4endl;
     }
 }
 

--- a/src/SimulationManager.cxx
+++ b/src/SimulationManager.cxx
@@ -18,8 +18,6 @@ SimulationManager::SimulationManager() {
         cout << "Only master thread should create the SimulationManager!" << endl;
         exit(1);
     }
-
-    fTimeStartUnix = chrono::steady_clock::now().time_since_epoch().count();
 }
 
 void SimulationManager::InitializeOutputManager() {
@@ -92,7 +90,7 @@ void SimulationManager::BeginOfRunAction() {
     if (G4Threading::IsMultithreadedApplication() && G4Threading::G4GetThreadId() != -1) {
         return;  // Only call this once from the main thread
     }
-
+    fTimeStartUnix = chrono::steady_clock::now().time_since_epoch().count();
 #ifndef GEANT4_WITHOUT_G4RunManagerFactory
     // gives segfault in old Geant4 versions such as 10.4.3, didn't look into it
     if (GetRestMetadata()->PrintProgress() ||


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 81](https://badgen.net/badge/PR%20Size/Ok%3A%2081/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-print-progress/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-print-progress) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-print-progress/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-print-progress) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-print-progress/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-print-progress) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-print-progress)](https://github.com/rest-for-physics/restG4/commits/lobis-print-progress)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Closes https://github.com/rest-for-physics/restG4/issues/80.

Updates to the progressive print output.

Now `SIGINT` handling occurs after being of run action instead of application run, which prevented users from exiting when geant4 was loading.