### PR TITLE
TF1/2 energy/angular distributions are now shared accross threads

### DIFF
--- a/include/PrimaryGeneratorAction.h
+++ b/include/PrimaryGeneratorAction.h
@@ -37,6 +37,9 @@ class PrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction {
     SimulationManager* fSimulationManager;
     std::mutex fMutex;
 
+    static std::mutex fDistributionInitializationMutex;
+    bool fDistributionInitialized = true;  // set to false on constructor if using formulas
+
     std::vector<TRestGeant4Particle> fTempParticles;
 
     G4ParticleGun fParticleGun;

--- a/include/PrimaryGeneratorAction.h
+++ b/include/PrimaryGeneratorAction.h
@@ -36,8 +36,7 @@ class PrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction {
    private:
     SimulationManager* fSimulationManager;
 
-    static std::mutex fDistributionInitializationMutex;
-    bool fDistributionInitialized = true;  // set to false on constructor if using formulas
+    static std::mutex fDistributionFormulaMutex;
 
     std::vector<TRestGeant4Particle> fTempParticles;
 
@@ -47,9 +46,9 @@ class PrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction {
     const TH1D* fEnergyDistributionHistogram = nullptr;
     const TH1D* fAngularDistributionHistogram = nullptr;
 
-    TF1* fEnergyDistributionFunction = nullptr;
-    TF1* fAngularDistributionFunction = nullptr;
-    TF2* fEnergyAndAngularDistributionFunction = nullptr;
+    static TF1* fEnergyDistributionFunction;
+    static TF1* fAngularDistributionFunction;
+    static TF2* fEnergyAndAngularDistributionFunction;
 
     TF3* fGeneratorSpatialDensityFunction;
 

--- a/include/PrimaryGeneratorAction.h
+++ b/include/PrimaryGeneratorAction.h
@@ -35,7 +35,6 @@ class PrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction {
 
    private:
     SimulationManager* fSimulationManager;
-    std::mutex fMutex;
 
     static std::mutex fDistributionInitializationMutex;
     bool fDistributionInitialized = true;  // set to false on constructor if using formulas

--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -86,7 +86,9 @@ PrimaryGeneratorAction::PrimaryGeneratorAction(SimulationManager* simulationMana
             }
             fEnergyDistributionFunction->SetRange(newRangeXMin, newRangeXMax);
             fEnergyDistributionFunction->SetNpx(source->GetEnergyDistributionFormulaNPoints());
+            cout << "Initializing energy distribution function" << endl;
             fEnergyDistributionFunction->GetRandom();
+            cout << "Energy distribution function initialization done" << endl;
         }
     }
 
@@ -110,7 +112,9 @@ PrimaryGeneratorAction::PrimaryGeneratorAction(SimulationManager* simulationMana
             }
             fAngularDistributionFunction->SetRange(newRangeXMin, newRangeXMax);
             fAngularDistributionFunction->SetNpx(source->GetAngularDistributionFormulaNPoints());
+            cout << "Initializing angular distribution function" << endl;
             fAngularDistributionFunction->GetRandom();
+            cout << "Angular distribution function initialization done" << endl;
         }
     }
 
@@ -164,7 +168,9 @@ PrimaryGeneratorAction::PrimaryGeneratorAction(SimulationManager* simulationMana
             fSimulationManager->GetRestMetadata()->GetParticleSource()->SetAngularDistributionRange(
                 {newAngularRangeXMin, newAngularRangeXMax});
             double x, y;
+            cout << "Initializing energy/angular distribution function" << endl;
             fEnergyAndAngularDistributionFunction->GetRandom2(x, y);
+            cout << "Energy/angular distribution function initialization done" << endl;
         }
     } else if (angularDistTypeEnum == AngularDistributionTypes::FORMULA2 ||
                energyDistTypeEnum == EnergyDistributionTypes::FORMULA2) {
@@ -792,7 +798,6 @@ void PrimaryGeneratorAction::SetParticleEnergyAndDirection(Int_t particleSourceI
         lock_guard<mutex> lock(fDistributionFormulaMutex);
         fEnergyAndAngularDistributionFunction->GetRandom2(energy, angle, fRandom);
     }
-    energy *= keV;
 
     G4ThreeVector direction = {source->GetDirection().X(), source->GetDirection().Y(),
                                source->GetDirection().Z()};

--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -242,8 +242,6 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* event) {
         cout << "Finished initialization of random distributions for thread " << G4Threading::G4GetThreadId()
              << endl;
     }
-    std::lock_guard<std::mutex> lock(fMutex);  // TODO: remove this lock after fixing problems
-
     auto simulationManager = fSimulationManager;
     TRestGeant4Metadata* restG4Metadata = simulationManager->GetRestMetadata();
 

--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -798,6 +798,7 @@ void PrimaryGeneratorAction::SetParticleEnergyAndDirection(Int_t particleSourceI
         lock_guard<mutex> lock(fDistributionFormulaMutex);
         fEnergyAndAngularDistributionFunction->GetRandom2(energy, angle, fRandom);
     }
+    energy *= keV;
 
     G4ThreeVector direction = {source->GetDirection().X(), source->GetDirection().Y(),
                                source->GetDirection().Z()};

--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -215,6 +215,11 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* event) {
     if (!fDistributionInitialized) {
         fDistributionInitialized = true;
         lock_guard<mutex> lock(fDistributionInitializationMutex);
+        if (fSimulationManager->GetAbortFlag()) {
+            G4RunManager::GetRunManager()->AbortRun(false);  // Do a hard abort
+            fParticleGun.GeneratePrimaryVertex(event);       // if this is not present, it won't work
+            return;
+        }
         cout << "Initializing random distributions for thread " << G4Threading::G4GetThreadId() << endl;
 
         TRestGeant4ParticleSource* source = fSimulationManager->GetRestMetadata()->GetParticleSource(0);
@@ -271,8 +276,8 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* event) {
             exit(1);
         }
     }
-    // Set the particle(s)' position, multiple particles generated from multiple
-    // sources shall always have a same origin
+    // Set the particle(s)' position, multiple particles generated from multiple sources shall always have a
+    // same origin
     SetParticlePosition();
 
     for (int i = 0; i < restG4Metadata->GetNumberOfSources(); i++) {


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Medium: 109](https://badgen.net/badge/PR%20Size/Medium%3A%20109/orange) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-formula-sampling-mt/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-formula-sampling-mt) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-formula-sampling-mt/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-formula-sampling-mt) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-formula-sampling-mt/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-formula-sampling-mt) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-formula-sampling-mt)](https://github.com/rest-for-physics/restG4/commits/lobis-formula-sampling-mt)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Before this PR each thread had a copy of the TF1/2 formula and could be sampled without the need of synchronization. The problem with this approach is that each distribution had to be initialized independently which resulted in too much waiting time. At the end a single distribution is shared between threads and a mutex is added for sync, which does not result in appreciable delay.