### PR TITLE
fix bad visualization with default settings, update default "activateAllVolumes" to true

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -428,7 +428,7 @@ jobs:
         run: |
           source ${{ env.REST_PATH }}/thisREST.sh
           cd ${{ env.REST_PATH }}/examples/restG4/13.IAXO/
-          restG4 Neutrons.rml -o Neutrons.root -e 1
+          restG4 Neutrons.rml -o Neutrons.root
           restRoot -b -q Validate.C'("Neutrons.root")'
 
   restG4-examples-14:

--- a/examples/01.NLDBD/NLDBD.rml
+++ b/examples/01.NLDBD/NLDBD.rml
@@ -68,8 +68,9 @@ By default REST units are mm, keV and degrees
         </biasing>
 
         <detector>
-            <parameter name="energyRange" value="(0,5)" units="MeV"/>
             <parameter name="activateAllVolumes" value="false"/>
+            <parameter name="energyRange" value="(0,5)" units="MeV"/>
+
             <volume name="gas" sensitive="true" maxStepSize="1mm"/>
         </detector>
 

--- a/examples/03.Fluorescence/electron.rml
+++ b/examples/03.Fluorescence/electron.rml
@@ -49,6 +49,8 @@ By default REST units are mm, keV and degrees
 
         <detector>
             <parameter name="energyRange" value="(0,30)" units="keV"/>
+            <parameter name="activateAllVolumes" value="false"/>
+
             <volume name="detector" sensitive="true" maxStepSize="1mm"/>
         </detector>
 

--- a/examples/03.Fluorescence/gamma.rml
+++ b/examples/03.Fluorescence/gamma.rml
@@ -48,6 +48,8 @@ By default REST units are mm, keV and degrees
 
         <detector>
             <parameter name="energyRange" value="(0,30)" units="keV"/>
+            <parameter name="activateAllVolumes" value="false"/>
+
             <volume name="detector" sensitive="true"/>
         </detector>
 

--- a/examples/04.MuonScan/CosmicMuons.rml
+++ b/examples/04.MuonScan/CosmicMuons.rml
@@ -32,6 +32,8 @@
         </generator>
 
         <detector>
+            <parameter name="activateAllVolumes" value="false"/>
+
             <volume name="det_dw_01" sensitive="true" maxStepSize="1mm"/>
             <volume name="det_up_01" maxStepSize="1mm"/>
         </detector>

--- a/examples/04.MuonScan/CosmicMuonsFromCircle.rml
+++ b/examples/04.MuonScan/CosmicMuonsFromCircle.rml
@@ -35,6 +35,8 @@
         </generator>
 
         <detector>
+            <parameter name="activateAllVolumes" value="false"/>
+
             <volume name="det_dw_01" sensitive="true" maxStepSize="1mm"/>
             <volume name="det_up_01" maxStepSize="1mm"/>
         </detector>

--- a/examples/04.MuonScan/CosmicMuonsFromWall.rml
+++ b/examples/04.MuonScan/CosmicMuonsFromWall.rml
@@ -36,6 +36,8 @@ First concept author G. Luzón (16-11-2020) -->
         </generator>
 
         <detector>
+            <parameter name="activateAllVolumes" value="false"/>
+
             <volume name="det_dw_01" sensitive="true" maxStepSize="1mm"/>
             <volume name="det_up_01" maxStepSize="1mm"/>
         </detector>

--- a/examples/04.MuonScan/MuonsFromPoint.rml
+++ b/examples/04.MuonScan/MuonsFromPoint.rml
@@ -17,12 +17,14 @@
         <parameter name="saveAllEvents" value="off"/>
         <parameter name="seed" value="17021981"/>
         <generator type="point" position="(0,0,-50)cm">
-            <source particle="mu-">
+            <source particle="geantino">
                 <energy type="mono" energy="100GeV"/>
                 <angular type="flux" direction="(0,0,1)"/>
             </source>
         </generator>
         <detector>
+            <parameter name="activateAllVolumes" value="false"/>
+
             <volume name="det_dw_01" sensitive="true" maxStepSize="1mm"/>
             <volume name="det_up_01" maxStepSize="1mm"/>
         </detector>

--- a/examples/04.MuonScan/MuonsFromPoint.rml
+++ b/examples/04.MuonScan/MuonsFromPoint.rml
@@ -17,7 +17,7 @@
         <parameter name="saveAllEvents" value="off"/>
         <parameter name="seed" value="17021981"/>
         <generator type="point" position="(0,0,-50)cm">
-            <source particle="geantino">
+            <source particle="mu-">
                 <energy type="mono" energy="100GeV"/>
                 <angular type="flux" direction="(0,0,1)"/>
             </source>

--- a/examples/05.PandaXIII/Xe136bb0n.rml
+++ b/examples/05.PandaXIII/Xe136bb0n.rml
@@ -35,6 +35,8 @@
 
         <detector>
             <parameter name="energyRange" value="(0,10)MeV"/>
+            <parameter name="activateAllVolumes" value="false"/>
+
             <volume name="Gas" sensitive="true" maxStepSize="200um"/>
         </detector>
 

--- a/examples/13.IAXO/Neutrons.rml
+++ b/examples/13.IAXO/Neutrons.rml
@@ -26,15 +26,12 @@ Author: Luis Obis (lobis@unizar.es)
 
         <detector>
             <parameter name="maxStepSize" value="1mm"/>
-            <parameter name="activateAllVolumes" value="true"/>
-
             <removeUnwantedTracks enabled="true" keepZeroEnergyTracks="true"/>
 
             <volume name="gasVolume" sensitive="true" maxStepSize="0.05mm"/>
             <volume name="^scintillatorVolume" sensitive="false" keepTracks="true" maxStepSize="0.5mm"/>
             <volume name="^captureLayerVolume" sensitive="false" keepTracks="true" maxStepSize="0.05mm"/>
             <volume name="ShieldingVolume" sensitive="false" maxStepSize="5mm"/>
-
         </detector>
     </TRestGeant4Metadata>
 

--- a/examples/13.IAXO/Neutrons.rml
+++ b/examples/13.IAXO/Neutrons.rml
@@ -12,7 +12,7 @@ Author: Luis Obis (lobis@unizar.es)
     <TRestGeant4Metadata>
         <parameter name="gdmlFile" value="geometry/setup.gdml"/>
         <parameter name="seed" value="170211"/>
-        <parameter name="nEvents" value="10000"/>
+        <parameter name="nRequestedEntries" value="1"/>
 
         <generator type="surface" shape="circle"
                    position="(0,1250,0)mm" size="(100,0,0)mm"

--- a/examples/13.IAXO/Neutrons.rml
+++ b/examples/13.IAXO/Neutrons.rml
@@ -11,16 +11,14 @@ Author: Luis Obis (lobis@unizar.es)
 
     <TRestGeant4Metadata>
         <parameter name="gdmlFile" value="geometry/setup.gdml"/>
-        <parameter name="seed" value="170211"/>
+        <parameter name="seed" value="17022"/>
         <parameter name="nRequestedEntries" value="1"/>
 
-        <generator type="surface" shape="circle"
-                   position="(0,1250,0)mm" size="(100,0,0)mm"
-                   rotationAngle="90deg" rotationAxis="(1,0,0)">
+        <generator type="cosmic">
             <source particle="neutron">
                 <energy type="formula" name="CosmicNeutrons"
-                        range="(10,10000)MeV" nPoints="2000"/>  <!-- By default, ranges from 0.1 MeV to 10 GeV -->
-                <angular type="formula" name="Cos2" direction="(0,-1,0)" nPoints="300"/>
+                        range="(10,10000)MeV" nPoints="10000"/>  <!-- By default, ranges from 0.1 MeV to 10 GeV -->
+                <angular type="formula" name="Cos2" direction="(0,-1,0)" nPoints="1000"/>
             </source>
         </generator>
 
@@ -61,7 +59,9 @@ Author: Luis Obis (lobis@unizar.es)
             <option name="ARM" value="true"/>
         </physicsList>
 
+        <!--
         <physicsList name="G4NeutronTrackingCut"/>
+         -->
 
     </TRestGeant4PhysicsLists>
 </restG4>

--- a/examples/13.IAXO/Validate.C
+++ b/examples/13.IAXO/Validate.C
@@ -28,13 +28,13 @@ Int_t Validate(const char* filename) {
         return 3;
     }
 
-    if (metadata->GetParticleSource()->GetEnergyDistributionFormulaNPoints() != 2000) {
+    if (metadata->GetParticleSource()->GetEnergyDistributionFormulaNPoints() != 10000) {
         cout << "Incorrect number of sampling points on energy distribution: "
              << metadata->GetParticleSource()->GetEnergyDistributionFormulaNPoints() << endl;
         return 4;
     }
 
-    if (metadata->GetParticleSource()->GetAngularDistributionFormulaNPoints() != 300) {
+    if (metadata->GetParticleSource()->GetAngularDistributionFormulaNPoints() != 1000) {
         cout << "Incorrect number of sampling points on angular distribution: "
              << metadata->GetParticleSource()->GetAngularDistributionFormulaNPoints() << endl;
         return 5;
@@ -44,25 +44,25 @@ Int_t Validate(const char* filename) {
     TRestGeant4Event* event = run.GetInputEvent<TRestGeant4Event>();
     run.GetEntry(0);
 
-    if (event->GetNumberOfTracks() != 170) {
+    if (event->GetNumberOfTracks() != 1501) {
         cout << "Incorrect number of tracks: " << event->GetNumberOfTracks() << endl;
         return 6;
     }
-    if (event->GetNumberOfHits() != 2933) {
+    if (event->GetNumberOfHits() != 13990) {
         cout << "Incorrect number of hits: " << event->GetNumberOfHits() << endl;
         return 7;
     }
 
-    constexpr Double_t sensitiveVolumeEnergyRef = 11.4479;
+    constexpr Double_t sensitiveVolumeEnergyRef = 17.6779;
     if (TMath::Abs(event->GetSensitiveVolumeEnergy() - sensitiveVolumeEnergyRef) > 1e-4) {
         cout << "Incorrect sensitive volume energy: " << event->GetSensitiveVolumeEnergy() << endl;
         return 8;
     }
 
     const auto scintillatorVolumeName =
-        "VetoSystem_vetoSystemEast_vetoLayerEast1_assembly-13.veto1_scintillatorVolume-1500.0mm-f1a5df68";
+        "VetoSystem_vetoSystemWest_vetoLayerWest1_assembly-16.veto1_scintillatorVolume-1500.0mm-f1a5df6b";
     const auto scintillatorEnergy = event->GetEnergyInVolume(scintillatorVolumeName);
-    const auto scintillatorEnergyRef = 2237.1460;
+    const auto scintillatorEnergyRef = 12246.9;
     if (TMath::Abs(scintillatorEnergy - scintillatorEnergyRef) > 1e-4) {
         cout << "Incorrect scintillator volume energy: " << scintillatorEnergy << endl;
         return 9;

--- a/examples/13.IAXO/Validate.C
+++ b/examples/13.IAXO/Validate.C
@@ -63,7 +63,7 @@ Int_t Validate(const char* filename) {
         "VetoSystem_vetoSystemWest_vetoLayerWest1_assembly-16.veto1_scintillatorVolume-1500.0mm-f1a5df6b";
     const auto scintillatorEnergy = event->GetEnergyInVolume(scintillatorVolumeName);
     const auto scintillatorEnergyRef = 12246.9;
-    if (TMath::Abs(scintillatorEnergy - scintillatorEnergyRef) > 1e-4) {
+    if (TMath::Abs(scintillatorEnergy - scintillatorEnergyRef) / scintillatorEnergyRef > 0.001) {
         cout << "Incorrect scintillator volume energy: " << scintillatorEnergy << endl;
         return 9;
     }
@@ -81,7 +81,7 @@ Int_t Validate(const char* filename) {
         }
     }
 
-    if (TMath::Abs(scintillatorEnergyFromTracks - scintillatorEnergyRef) > 1e-4) {
+    if (TMath::Abs(scintillatorEnergyFromTracks - scintillatorEnergyRef) / scintillatorEnergyRef > 0.001) {
         cout << "Incorrect scintillator volume energy from tracks: " << scintillatorEnergyFromTracks << endl;
         return 10;
     }

--- a/examples/13.IAXO/geometry/setup.gdml
+++ b/examples/13.IAXO/geometry/setup.gdml
@@ -374,7 +374,7 @@
             <first ref="scintillatorLightGuide1Solid-800.0mm"/>
             <second ref="scintillatorLightGuide2Solid-800.0mm"/>
         </union>
-        <box lunit="mm" aunit="rad" name="worldBox" x="5000.0" y="5000.0" z="5000.0"/>
+        <box lunit="mm" aunit="rad" name="worldBox" x="1350.0" y="1350.0" z="3000.0"/>
     </solids>
     <structure>
         <volume name="chamberBodyVolume">

--- a/src/DataModel.cxx
+++ b/src/DataModel.cxx
@@ -154,6 +154,11 @@ void TRestGeant4Hits::InsertStep(const G4Step* step) {
     const auto& volumeNameGeant4 = step->GetPreStepPoint()->GetPhysicalVolume()->GetName();
     const auto& volumeName = geometryInfo.GetAlternativeNameFromGeant4PhysicalName(volumeNameGeant4);
 
+    if (!metadata->IsActiveVolume(volumeName) && step->GetTrack()->GetCurrentStepNumber() != 0) {
+        // we always store the first step
+        return;
+    }
+
     const bool kill = metadata->IsKillVolume(volumeName);
 
     const auto& particle = step->GetTrack()->GetDefinition();

--- a/src/DataModel.cxx
+++ b/src/DataModel.cxx
@@ -156,11 +156,6 @@ void TRestGeant4Hits::InsertStep(const G4Step* step) {
 
     const bool kill = metadata->IsKillVolume(volumeName);
 
-    if (!metadata->IsActiveVolume(volumeName) && step->GetTrack()->GetCurrentStepNumber() != 0) {
-        // we always store the first step
-        return;
-    }
-
     const auto& particle = step->GetTrack()->GetDefinition();
     const auto& particleID = particle->GetPDGEncoding();
     const auto& particleName = particle->GetParticleName();


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 36](https://badgen.net/badge/PR%20Size/Ok%3A%2036/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-fix-bad-view/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-fix-bad-view) [![](https://gitlab.cern.ch/rest-for-physics/geant4lib/badges/lobis-fix-bad-view/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/geant4lib/-/commits/lobis-fix-bad-view) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-fix-bad-view/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-fix-bad-view) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-fix-bad-view)](https://github.com/rest-for-physics/restG4/commits/lobis-fix-bad-view)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The visualizaiton does not work correctly unless the user activates all volumes, as the tracks will be clipped otherwise, and the particles won't exit the world volume (since its not activated, the step is not recorded).

I have updated the defaults so that all volumes are activated by default (previously this was the case if no volume was manually activated only). This way the visualization will work properly by default. I have also updated the corresponding examples to explicitly avoid activating all volumes, so that we don't have to modify validation values.