### PR TITLE
Avoid error due to deprecated ICM option

### DIFF
--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -23,6 +23,7 @@
 #include <G4NeutronTrackingCut.hh>
 #include <G4ParticleTable.hh>
 #include <G4ParticleTypes.hh>
+#include <G4PhotonEvaporation.hh>
 #include <G4ProcessManager.hh>
 #include <G4ProductionCuts.hh>
 #include <G4RadioactiveDecay.hh>
@@ -241,12 +242,22 @@ void PhysicsList::ConstructProcess() {
         radioactiveDecay->SetHLThreshold(decayTimeThreshold);
 #else
         radioactiveDecay->SetThresholdForVeryLongDecayTime(decayTimeThreshold);
+        // For ICM option
+        auto photonEvaporation = new G4PhotonEvaporation();
 #endif
         // Setting Internal Conversion (ICM) option.
         if (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "ICM") == "true") {
+#ifdef GEANT4_VERSION_LESS_11_0_0
             radioactiveDecay->SetICM(true);
+#else
+            photonEvaporation->SetICM(true);
+#endif
         } else if (fRestPhysicsLists->GetPhysicsListOptionValue("G4RadioactiveDecay", "ICM") == "false") {
+#ifdef GEANT4_VERSION_LESS_11_0_0
             radioactiveDecay->SetICM(false);
+#else
+            photonEvaporation->SetICM(false);
+#endif
         } else if (fRestPhysicsLists->GetVerboseLevel() >=
                    TRestStringOutput::REST_Verbose_Level::REST_Essential) {
             RESTWarning << "PhysicsList 'G4RadioactiveDecay' option 'ICM' not defined" << RESTendl;


### PR DESCRIPTION
In the latest release of Geant4 (v11.1.0) the ICM option appears to be deprecated, as it can be read in the [release notes](https://github.com/Geant4/geant4/blob/v11.1.0/ReleaseNotes/ReleaseNotes.11.1.html).

I have never used this option, I would love to know if anyone has some insight in this topic.

I modified the code to maintain compatilbity with older (10.4.3) version (I am not a fan of all this branching with `#ifdef` but...). I attempted to keep the original funtionality of the ICM option in my changes but I am not sure how to check it works correctly, or if it was working correctly in the first place anyway.