### PR TITLE
Adding workflow call to restG4 validation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,6 +2,7 @@ name: Validation
 
 on:
   workflow_dispatch:
+  workflow_call:
 
   push:
     branches: [ master ]


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/submodule-validation/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/submodule-validation) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=submodule-validation)](https://github.com/rest-for-physics/restG4/commits/submodule-validation)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added workflow call to restG4 validation pipeline to be able to run the CI from framework branch

Contributes to https://github.com/rest-for-physics/framework/issues/372