### PR TITLE
selecting gdml volume will also choose logical volume if physical doe…

### DIFF
--- a/src/DetectorConstruction.cxx
+++ b/src/DetectorConstruction.cxx
@@ -22,16 +22,16 @@
 using namespace std;
 using namespace TRestGeant4PrimaryGeneratorTypes;
 
-DetectorConstruction::DetectorConstruction(SimulationManager *simulationManager)
-        : fSimulationManager(simulationManager) {
+DetectorConstruction::DetectorConstruction(SimulationManager* simulationManager)
+    : fSimulationManager(simulationManager) {
     G4cout << "Detector Construction" << G4endl;
     fGdmlParser = new G4GDMLParser();
 }
 
 DetectorConstruction::~DetectorConstruction() { delete fGdmlParser; }
 
-G4VPhysicalVolume *DetectorConstruction::Construct() {
-    TRestGeant4Metadata *restG4Metadata = fSimulationManager->GetRestMetadata();
+G4VPhysicalVolume* DetectorConstruction::Construct() {
+    TRestGeant4Metadata* restG4Metadata = fSimulationManager->GetRestMetadata();
 
     cout << "Isotope table " << endl;
     cout << *(G4Isotope::GetIsotopeTable()) << endl;
@@ -44,31 +44,31 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
     const auto startingPath = filesystem::current_path();
 
     const auto [gdmlPath, gdmlToRead] =
-            TRestTools::SeparatePathAndName((string) restG4Metadata->GetGdmlFilename());
+        TRestTools::SeparatePathAndName((string)restG4Metadata->GetGdmlFilename());
     filesystem::current_path(gdmlPath);
 
     G4cout << "gdmlToRead: " << gdmlToRead << G4endl;
 
     fGdmlParser->Read(gdmlToRead, false);
-    G4VPhysicalVolume *worldVolume = fGdmlParser->GetWorldVolume();
+    G4VPhysicalVolume* worldVolume = fGdmlParser->GetWorldVolume();
 
-    const auto worldSolid = dynamic_cast<G4Box *>(worldVolume->GetLogicalVolume()->GetSolid());
+    const auto worldSolid = dynamic_cast<G4Box*>(worldVolume->GetLogicalVolume()->GetSolid());
     restG4Metadata->fGeant4PrimaryGeneratorInfo.fSpatialGeneratorWorldSize = {
-            worldSolid->GetXHalfLength(), worldSolid->GetYHalfLength(), worldSolid->GetZHalfLength()};
+        worldSolid->GetXHalfLength(), worldSolid->GetYHalfLength(), worldSolid->GetZHalfLength()};
 
     restG4Metadata->fGeant4GeometryInfo.InitializeOnDetectorConstruction(gdmlToRead, worldVolume);
     restG4Metadata->ReadDetector();
     restG4Metadata->PrintMetadata();  // now we have detector info
 
-    const auto &geometryInfo = restG4Metadata->GetGeant4GeometryInfo();
+    const auto& geometryInfo = restG4Metadata->GetGeant4GeometryInfo();
     geometryInfo.Print();
 
     // do some checks
     {
         // Check all physical volume names are unique
-        G4PhysicalVolumeStore *physicalVolumeStore = G4PhysicalVolumeStore::GetInstance();
+        G4PhysicalVolumeStore* physicalVolumeStore = G4PhysicalVolumeStore::GetInstance();
         set<string> physicalVolumeNames;
-        vector<G4VPhysicalVolume *>::const_iterator physicalVolume;
+        vector<G4VPhysicalVolume*>::const_iterator physicalVolume;
         for (physicalVolume = physicalVolumeStore->begin(); physicalVolume != physicalVolumeStore->end();
              physicalVolume++) {
             auto name = (*physicalVolume)->GetName();
@@ -83,9 +83,9 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
         }
 
         // Check all logical volume names are unique
-        G4LogicalVolumeStore *logicalVolumeStore = G4LogicalVolumeStore::GetInstance();
+        G4LogicalVolumeStore* logicalVolumeStore = G4LogicalVolumeStore::GetInstance();
         set<string> logicalVolumeNames;
-        vector<G4LogicalVolume *>::const_iterator logicalVolume;
+        vector<G4LogicalVolume*>::const_iterator logicalVolume;
         for (logicalVolume = logicalVolumeStore->begin(); logicalVolume != logicalVolumeStore->end();
              logicalVolume++) {
             auto name = (*logicalVolume)->GetName();
@@ -101,15 +101,15 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
     }
     filesystem::current_path(startingPath);
 
-    auto sensitiveVolume = (string) restG4Metadata->GetSensitiveVolume();
-    G4VPhysicalVolume *physicalVolume = GetPhysicalVolume(sensitiveVolume);
+    auto sensitiveVolume = (string)restG4Metadata->GetSensitiveVolume();
+    G4VPhysicalVolume* physicalVolume = GetPhysicalVolume(sensitiveVolume);
     if (physicalVolume == nullptr) {
         // sensitive volume was not found, perhaps the user specified a logical volume
         auto physicalVolumes = geometryInfo.GetAllPhysicalVolumesFromLogical(sensitiveVolume);
         if (physicalVolumes.size() == 1) {
             restG4Metadata->InsertSensitiveVolume(
-                    geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolumes[0]));
-            sensitiveVolume = (string) restG4Metadata->GetSensitiveVolume();
+                geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolumes[0]));
+            sensitiveVolume = (string)restG4Metadata->GetSensitiveVolume();
             physicalVolume = GetPhysicalVolume(sensitiveVolume);
         }
     }
@@ -123,20 +123,20 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
     Double_t my = restG4Metadata->GetMagneticField().Y() * tesla;
     Double_t mz = restG4Metadata->GetMagneticField().Z() * tesla;
 
-    G4MagneticField *magField = new G4UniformMagField(G4ThreeVector(mx, my, mz));
+    G4MagneticField* magField = new G4UniformMagField(G4ThreeVector(mx, my, mz));
     // G4FieldManager* localFieldMgr = new G4FieldManager(magField);
-    G4FieldManager *fieldMgr = G4TransportationManager::GetTransportationManager()->GetFieldManager();
+    G4FieldManager* fieldMgr = G4TransportationManager::GetTransportationManager()->GetFieldManager();
     fieldMgr->SetDetectorField(magField);
     fieldMgr->CreateChordFinder(magField);
 
-    G4LogicalVolume *volume = physicalVolume->GetLogicalVolume();
-    G4Material *material = volume->GetMaterial();
+    G4LogicalVolume* volume = physicalVolume->GetLogicalVolume();
+    G4Material* material = volume->GetMaterial();
     G4cout << "Sensitive volume properties:" << G4endl;
     G4cout << "\t- Material: " << material->GetName() << G4endl;
     G4cout << "\t- Temperature: " << material->GetTemperature() << " K" << G4endl;
     G4cout << "\t- Density: " << material->GetDensity() / (g / cm3) << " g/cm3" << G4endl;
 
-    const auto &primaryGeneratorInfo = restG4Metadata->GetGeant4PrimaryGeneratorInfo();
+    const auto& primaryGeneratorInfo = restG4Metadata->GetGeant4PrimaryGeneratorInfo();
     // Getting generation volume
     const auto fromVolume = primaryGeneratorInfo.GetSpatialGeneratorFrom();
     if (fromVolume != "NO_SUCH_PARA") {
@@ -145,20 +145,21 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
     cout << "Generator type: " << primaryGeneratorInfo.GetSpatialGeneratorType() << endl;
 
     const auto spatialGeneratorTypeEnum =
-            StringToSpatialGeneratorTypes(primaryGeneratorInfo.GetSpatialGeneratorType().Data());
+        StringToSpatialGeneratorTypes(primaryGeneratorInfo.GetSpatialGeneratorType().Data());
 
     if (spatialGeneratorTypeEnum == TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypes::VOLUME &&
         primaryGeneratorInfo.GetSpatialGeneratorFrom() != "Not defined") {
-        G4VPhysicalVolume *physicalVolume = GetPhysicalVolume(primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());
+        G4VPhysicalVolume* physicalVolume =
+            GetPhysicalVolume(primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());
         if (physicalVolume == nullptr) {
             // perhaps the user selected a logical volume instead
             auto physicalVolumes = geometryInfo.GetAllPhysicalVolumesFromLogical(
-                    primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());
+                primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());
             if (physicalVolumes.size() == 1) {
                 physicalVolume = GetPhysicalVolume(physicalVolumes[0].Data());
                 cout << "Generator volume '" << primaryGeneratorInfo.GetSpatialGeneratorFrom()
-                     << "' was not found in the geometry. Using the physical volume '"
-                     << physicalVolumes[0] << "' instead, which was obtained from logical volume '"
+                     << "' was not found in the geometry. Using the physical volume '" << physicalVolumes[0]
+                     << "' instead, which was obtained from logical volume '"
                      << primaryGeneratorInfo.GetSpatialGeneratorFrom() << "'" << endl;
             }
         }
@@ -172,7 +173,7 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
         if (spatialGeneratorTypeEnum == TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypes::SURFACE ||
             spatialGeneratorTypeEnum == TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypes::VOLUME) {
             restG4Metadata->fGeant4PrimaryGeneratorInfo.fSpatialGeneratorPosition = {
-                    fGeneratorTranslation.x(), fGeneratorTranslation.y(), fGeneratorTranslation.z()};
+                fGeneratorTranslation.x(), fGeneratorTranslation.y(), fGeneratorTranslation.z()};
         }
 
         fGeneratorSolid = physicalVolume->GetLogicalVolume()->GetSolid();
@@ -213,13 +214,14 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
 
     for (unsigned int id = 0; id < restG4Metadata->GetNumberOfActiveVolumes(); id++) {
         TString activeVolumeName = restG4Metadata->GetActiveVolumeName(id);
-        G4VPhysicalVolume *physicalVolume = GetPhysicalVolume((G4String) activeVolumeName);
+        G4VPhysicalVolume* physicalVolume = GetPhysicalVolume((G4String)activeVolumeName);
         if (physicalVolume != nullptr) {
-            G4LogicalVolume *logicalVolume = physicalVolume->GetLogicalVolume();
+            G4LogicalVolume* logicalVolume = physicalVolume->GetLogicalVolume();
             if (restG4Metadata->GetMaxStepSize(activeVolumeName) > 0) {
                 RESTInfo << "Setting maxStepSize of " << restG4Metadata->GetMaxStepSize(activeVolumeName) * mm
                          << "mm for volume '" << activeVolumeName << "'" << RESTendl;
-                logicalVolume->SetUserLimits(new G4UserLimits(restG4Metadata->GetMaxStepSize(activeVolumeName) * mm));
+                logicalVolume->SetUserLimits(
+                    new G4UserLimits(restG4Metadata->GetMaxStepSize(activeVolumeName) * mm));
             }
         } else {
             cerr << "DetectorConstruction::Construct - Volume '" << activeVolumeName
@@ -231,15 +233,15 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
     return worldVolume;
 }
 
-G4VPhysicalVolume *DetectorConstruction::GetPhysicalVolume(const G4String &physicalVolumeName) const {
-    G4PhysicalVolumeStore *physicalVolumeStore = G4PhysicalVolumeStore::GetInstance();
-    TRestGeant4Metadata *restG4Metadata = fSimulationManager->GetRestMetadata();
-    const auto &geometryInfo = restG4Metadata->GetGeant4GeometryInfo();
-    vector<G4VPhysicalVolume *>::const_iterator physicalVolume;
+G4VPhysicalVolume* DetectorConstruction::GetPhysicalVolume(const G4String& physicalVolumeName) const {
+    G4PhysicalVolumeStore* physicalVolumeStore = G4PhysicalVolumeStore::GetInstance();
+    TRestGeant4Metadata* restG4Metadata = fSimulationManager->GetRestMetadata();
+    const auto& geometryInfo = restG4Metadata->GetGeant4GeometryInfo();
+    vector<G4VPhysicalVolume*>::const_iterator physicalVolume;
     for (physicalVolume = physicalVolumeStore->begin(); physicalVolume != physicalVolumeStore->end();
          physicalVolume++) {
         auto name = (*physicalVolume)->GetName();
-        auto alternativeName = (G4String) geometryInfo.GetAlternativeNameFromGeant4PhysicalName(name);
+        auto alternativeName = (G4String)geometryInfo.GetAlternativeNameFromGeant4PhysicalName(name);
         if (name == physicalVolumeName || alternativeName == physicalVolumeName) {
             return *physicalVolume;
         }
@@ -249,20 +251,20 @@ G4VPhysicalVolume *DetectorConstruction::GetPhysicalVolume(const G4String &physi
 }
 
 void DetectorConstruction::ConstructSDandField() {
-    const TRestGeant4Metadata &metadata = *fSimulationManager->GetRestMetadata();
+    const TRestGeant4Metadata& metadata = *fSimulationManager->GetRestMetadata();
 
-    set<G4LogicalVolume *> logicalVolumesSelected;
-    for (const auto &userSensitiveVolume: metadata.GetSensitiveVolumes()) {
+    set<G4LogicalVolume*> logicalVolumesSelected;
+    for (const auto& userSensitiveVolume : metadata.GetSensitiveVolumes()) {
         // Each sensitive detector declaration in the RML should correspond to at least one logical volume
-        G4LogicalVolume *logicalVolume;
+        G4LogicalVolume* logicalVolume;
         // Check if user selected a Geant4 physical volume by name
-        G4VPhysicalVolume *physicalVolume =
-                G4PhysicalVolumeStore::GetInstance()->GetVolume(userSensitiveVolume.Data(), false);
+        G4VPhysicalVolume* physicalVolume =
+            G4PhysicalVolumeStore::GetInstance()->GetVolume(userSensitiveVolume.Data(), false);
         if (physicalVolume == nullptr) {
             const G4String geant4VolumeName =
-                    metadata.GetGeant4GeometryInfo()
-                            .GetGeant4PhysicalNameFromAlternativeName(userSensitiveVolume.Data())
-                            .Data();
+                metadata.GetGeant4GeometryInfo()
+                    .GetGeant4PhysicalNameFromAlternativeName(userSensitiveVolume.Data())
+                    .Data();
             // Check if user selected a Geant4 physical volume by REST name (only relevant for assemblies)
             physicalVolume = G4PhysicalVolumeStore::GetInstance()->GetVolume(geant4VolumeName, false);
         }
@@ -279,25 +281,25 @@ void DetectorConstruction::ConstructSDandField() {
             // Check if the user string matches a logical volume by expanding the input as a regex
             // This can have multiple hits
             const auto logicalVolumesMatchingExpression =
-                    metadata.GetGeant4GeometryInfo().GetAllLogicalVolumesMatchingExpression(userSensitiveVolume);
+                metadata.GetGeant4GeometryInfo().GetAllLogicalVolumesMatchingExpression(userSensitiveVolume);
             if (logicalVolumesMatchingExpression.empty()) {
                 cerr << "Detector construction error: could not find matching logical volume(s) for '"
                      << userSensitiveVolume << "'" << endl;
                 exit(1);
             } else {
-                for (const auto &logicalVolumeName: logicalVolumesMatchingExpression) {
+                for (const auto& logicalVolumeName : logicalVolumesMatchingExpression) {
                     logicalVolumesSelected.insert(
-                            G4LogicalVolumeStore::GetInstance()->GetVolume(logicalVolumeName.Data(), false));
+                        G4LogicalVolumeStore::GetInstance()->GetVolume(logicalVolumeName.Data(), false));
                 }
             }
         }
     }
 
-    G4SDManager *SDManager = G4SDManager::GetSDMpointer();
+    G4SDManager* SDManager = G4SDManager::GetSDMpointer();
 
-    for (G4LogicalVolume *logicalVolume: logicalVolumesSelected) {
+    for (G4LogicalVolume* logicalVolume : logicalVolumesSelected) {
         auto name = logicalVolume->GetName();
-        G4VSensitiveDetector *sensitiveDetector = new SensitiveDetector(fSimulationManager, name);
+        G4VSensitiveDetector* sensitiveDetector = new SensitiveDetector(fSimulationManager, name);
         SDManager->AddNewDetector(sensitiveDetector);
         logicalVolume->SetSensitiveDetector(sensitiveDetector);
 
@@ -306,26 +308,26 @@ void DetectorConstruction::ConstructSDandField() {
     }
 }
 
-void TRestGeant4GeometryInfo::PopulateFromGeant4World(const G4VPhysicalVolume *world) {
-    auto detector = (DetectorConstruction *) G4RunManager::GetRunManager()->GetUserDetectorConstruction();
-    TRestGeant4Metadata *restG4Metadata = detector->fSimulationManager->GetRestMetadata();
+void TRestGeant4GeometryInfo::PopulateFromGeant4World(const G4VPhysicalVolume* world) {
+    auto detector = (DetectorConstruction*)G4RunManager::GetRunManager()->GetUserDetectorConstruction();
+    TRestGeant4Metadata* restG4Metadata = detector->fSimulationManager->GetRestMetadata();
 
     const size_t n = int(world->GetLogicalVolume()->GetNoDaughters());
     for (size_t i = 0; i < n + 1; i++) {  // world is the + 1
-        G4VPhysicalVolume *volume;
+        G4VPhysicalVolume* volume;
         if (i == n) {
-            volume = const_cast<G4VPhysicalVolume *>(world);
+            volume = const_cast<G4VPhysicalVolume*>(world);
         } else {
             volume = world->GetLogicalVolume()->GetDaughter(i);
         }
-        TString namePhysical = (TString) volume->GetName();
+        TString namePhysical = (TString)volume->GetName();
         if (fGdmlNewPhysicalNames.size() > i) {
             // it has been filled
             fGeant4PhysicalNameToNewPhysicalNameMap[namePhysical] = fGdmlNewPhysicalNames[i];
         }
         TString physicalNewName = GetAlternativeNameFromGeant4PhysicalName(namePhysical);
-        TString nameLogical = (TString) volume->GetLogicalVolume()->GetName();
-        TString nameMaterial = (TString) volume->GetLogicalVolume()->GetMaterial()->GetName();
+        TString nameLogical = (TString)volume->GetLogicalVolume()->GetName();
+        TString nameMaterial = (TString)volume->GetLogicalVolume()->GetMaterial()->GetName();
         auto position = volume->GetTranslation();
 
         fPhysicalToLogicalVolumeMap[physicalNewName] = nameLogical;

--- a/src/DetectorConstruction.cxx
+++ b/src/DetectorConstruction.cxx
@@ -22,16 +22,16 @@
 using namespace std;
 using namespace TRestGeant4PrimaryGeneratorTypes;
 
-DetectorConstruction::DetectorConstruction(SimulationManager* simulationManager)
-    : fSimulationManager(simulationManager) {
+DetectorConstruction::DetectorConstruction(SimulationManager *simulationManager)
+        : fSimulationManager(simulationManager) {
     G4cout << "Detector Construction" << G4endl;
     fGdmlParser = new G4GDMLParser();
 }
 
 DetectorConstruction::~DetectorConstruction() { delete fGdmlParser; }
 
-G4VPhysicalVolume* DetectorConstruction::Construct() {
-    TRestGeant4Metadata* restG4Metadata = fSimulationManager->GetRestMetadata();
+G4VPhysicalVolume *DetectorConstruction::Construct() {
+    TRestGeant4Metadata *restG4Metadata = fSimulationManager->GetRestMetadata();
 
     cout << "Isotope table " << endl;
     cout << *(G4Isotope::GetIsotopeTable()) << endl;
@@ -44,31 +44,31 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
     const auto startingPath = filesystem::current_path();
 
     const auto [gdmlPath, gdmlToRead] =
-        TRestTools::SeparatePathAndName((string)restG4Metadata->GetGdmlFilename());
+            TRestTools::SeparatePathAndName((string) restG4Metadata->GetGdmlFilename());
     filesystem::current_path(gdmlPath);
 
     G4cout << "gdmlToRead: " << gdmlToRead << G4endl;
 
     fGdmlParser->Read(gdmlToRead, false);
-    G4VPhysicalVolume* worldVolume = fGdmlParser->GetWorldVolume();
+    G4VPhysicalVolume *worldVolume = fGdmlParser->GetWorldVolume();
 
-    const auto worldSolid = dynamic_cast<G4Box*>(worldVolume->GetLogicalVolume()->GetSolid());
+    const auto worldSolid = dynamic_cast<G4Box *>(worldVolume->GetLogicalVolume()->GetSolid());
     restG4Metadata->fGeant4PrimaryGeneratorInfo.fSpatialGeneratorWorldSize = {
-        worldSolid->GetXHalfLength(), worldSolid->GetYHalfLength(), worldSolid->GetZHalfLength()};
+            worldSolid->GetXHalfLength(), worldSolid->GetYHalfLength(), worldSolid->GetZHalfLength()};
 
     restG4Metadata->fGeant4GeometryInfo.InitializeOnDetectorConstruction(gdmlToRead, worldVolume);
     restG4Metadata->ReadDetector();
     restG4Metadata->PrintMetadata();  // now we have detector info
 
-    const auto& geometryInfo = restG4Metadata->GetGeant4GeometryInfo();
+    const auto &geometryInfo = restG4Metadata->GetGeant4GeometryInfo();
     geometryInfo.Print();
 
     // do some checks
     {
         // Check all physical volume names are unique
-        G4PhysicalVolumeStore* physicalVolumeStore = G4PhysicalVolumeStore::GetInstance();
+        G4PhysicalVolumeStore *physicalVolumeStore = G4PhysicalVolumeStore::GetInstance();
         set<string> physicalVolumeNames;
-        vector<G4VPhysicalVolume*>::const_iterator physicalVolume;
+        vector<G4VPhysicalVolume *>::const_iterator physicalVolume;
         for (physicalVolume = physicalVolumeStore->begin(); physicalVolume != physicalVolumeStore->end();
              physicalVolume++) {
             auto name = (*physicalVolume)->GetName();
@@ -83,9 +83,9 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
         }
 
         // Check all logical volume names are unique
-        G4LogicalVolumeStore* logicalVolumeStore = G4LogicalVolumeStore::GetInstance();
+        G4LogicalVolumeStore *logicalVolumeStore = G4LogicalVolumeStore::GetInstance();
         set<string> logicalVolumeNames;
-        vector<G4LogicalVolume*>::const_iterator logicalVolume;
+        vector<G4LogicalVolume *>::const_iterator logicalVolume;
         for (logicalVolume = logicalVolumeStore->begin(); logicalVolume != logicalVolumeStore->end();
              logicalVolume++) {
             auto name = (*logicalVolume)->GetName();
@@ -101,15 +101,15 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
     }
     filesystem::current_path(startingPath);
 
-    auto sensitiveVolume = (string)restG4Metadata->GetSensitiveVolume();
-    G4VPhysicalVolume* physicalVolume = GetPhysicalVolume(sensitiveVolume);
+    auto sensitiveVolume = (string) restG4Metadata->GetSensitiveVolume();
+    G4VPhysicalVolume *physicalVolume = GetPhysicalVolume(sensitiveVolume);
     if (physicalVolume == nullptr) {
         // sensitive volume was not found, perhaps the user specified a logical volume
         auto physicalVolumes = geometryInfo.GetAllPhysicalVolumesFromLogical(sensitiveVolume);
         if (physicalVolumes.size() == 1) {
             restG4Metadata->InsertSensitiveVolume(
-                geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolumes[0]));
-            sensitiveVolume = (string)restG4Metadata->GetSensitiveVolume();
+                    geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolumes[0]));
+            sensitiveVolume = (string) restG4Metadata->GetSensitiveVolume();
             physicalVolume = GetPhysicalVolume(sensitiveVolume);
         }
     }
@@ -123,20 +123,20 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
     Double_t my = restG4Metadata->GetMagneticField().Y() * tesla;
     Double_t mz = restG4Metadata->GetMagneticField().Z() * tesla;
 
-    G4MagneticField* magField = new G4UniformMagField(G4ThreeVector(mx, my, mz));
+    G4MagneticField *magField = new G4UniformMagField(G4ThreeVector(mx, my, mz));
     // G4FieldManager* localFieldMgr = new G4FieldManager(magField);
-    G4FieldManager* fieldMgr = G4TransportationManager::GetTransportationManager()->GetFieldManager();
+    G4FieldManager *fieldMgr = G4TransportationManager::GetTransportationManager()->GetFieldManager();
     fieldMgr->SetDetectorField(magField);
     fieldMgr->CreateChordFinder(magField);
 
-    G4LogicalVolume* volume = physicalVolume->GetLogicalVolume();
-    G4Material* material = volume->GetMaterial();
+    G4LogicalVolume *volume = physicalVolume->GetLogicalVolume();
+    G4Material *material = volume->GetMaterial();
     G4cout << "Sensitive volume properties:" << G4endl;
     G4cout << "\t- Material: " << material->GetName() << G4endl;
     G4cout << "\t- Temperature: " << material->GetTemperature() << " K" << G4endl;
     G4cout << "\t- Density: " << material->GetDensity() / (g / cm3) << " g/cm3" << G4endl;
 
-    const auto& primaryGeneratorInfo = restG4Metadata->GetGeant4PrimaryGeneratorInfo();
+    const auto &primaryGeneratorInfo = restG4Metadata->GetGeant4PrimaryGeneratorInfo();
     // Getting generation volume
     const auto fromVolume = primaryGeneratorInfo.GetSpatialGeneratorFrom();
     if (fromVolume != "NO_SUCH_PARA") {
@@ -145,26 +145,37 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
     cout << "Generator type: " << primaryGeneratorInfo.GetSpatialGeneratorType() << endl;
 
     const auto spatialGeneratorTypeEnum =
-        StringToSpatialGeneratorTypes(primaryGeneratorInfo.GetSpatialGeneratorType().Data());
+            StringToSpatialGeneratorTypes(primaryGeneratorInfo.GetSpatialGeneratorType().Data());
 
     if (spatialGeneratorTypeEnum == TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypes::VOLUME &&
         primaryGeneratorInfo.GetSpatialGeneratorFrom() != "Not defined") {
-        G4VPhysicalVolume* pVol = GetPhysicalVolume(primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());
-        if (pVol == nullptr) {
-            cout << "ERROR: The generator volume '" << primaryGeneratorInfo.GetSpatialGeneratorFrom()
-                 << "'was not found in the geometry" << endl;
+        G4VPhysicalVolume *physicalVolume = GetPhysicalVolume(primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());
+        if (physicalVolume == nullptr) {
+            // perhaps the user selected a logical volume instead
+            auto physicalVolumes = geometryInfo.GetAllPhysicalVolumesFromLogical(
+                    primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());
+            if (physicalVolumes.size() == 1) {
+                physicalVolume = GetPhysicalVolume(physicalVolumes[0].Data());
+                cout << "Generator volume '" << primaryGeneratorInfo.GetSpatialGeneratorFrom()
+                     << "' was not found in the geometry. Using the physical volume '"
+                     << physicalVolumes[0] << "' instead, which was obtained from logical volume '"
+                     << primaryGeneratorInfo.GetSpatialGeneratorFrom() << "'" << endl;
+            }
+        }
+        if (physicalVolume == nullptr) {
+            cerr << "ERROR: The generator volume '" << primaryGeneratorInfo.GetSpatialGeneratorFrom()
+                 << "' was not found in the geometry" << endl;
             exit(1);
-            // return worldVolume;
         }
 
-        fGeneratorTranslation = pVol->GetTranslation();
+        fGeneratorTranslation = physicalVolume->GetTranslation();
         if (spatialGeneratorTypeEnum == TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypes::SURFACE ||
             spatialGeneratorTypeEnum == TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypes::VOLUME) {
             restG4Metadata->fGeant4PrimaryGeneratorInfo.fSpatialGeneratorPosition = {
-                fGeneratorTranslation.x(), fGeneratorTranslation.y(), fGeneratorTranslation.z()};
+                    fGeneratorTranslation.x(), fGeneratorTranslation.y(), fGeneratorTranslation.z()};
         }
 
-        fGeneratorSolid = pVol->GetLogicalVolume()->GetSolid();
+        fGeneratorSolid = physicalVolume->GetLogicalVolume()->GetSolid();
 
         fBoundBoxXMax = -1.e30;
         fBoundBoxYMax = -1.e30;
@@ -202,13 +213,13 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
 
     for (unsigned int id = 0; id < restG4Metadata->GetNumberOfActiveVolumes(); id++) {
         TString activeVolumeName = restG4Metadata->GetActiveVolumeName(id);
-        G4VPhysicalVolume* pVol = GetPhysicalVolume((G4String)activeVolumeName);
-        if (pVol != nullptr) {
-            G4LogicalVolume* lVol = pVol->GetLogicalVolume();
+        G4VPhysicalVolume *physicalVolume = GetPhysicalVolume((G4String) activeVolumeName);
+        if (physicalVolume != nullptr) {
+            G4LogicalVolume *logicalVolume = physicalVolume->GetLogicalVolume();
             if (restG4Metadata->GetMaxStepSize(activeVolumeName) > 0) {
                 RESTInfo << "Setting maxStepSize of " << restG4Metadata->GetMaxStepSize(activeVolumeName) * mm
                          << "mm for volume '" << activeVolumeName << "'" << RESTendl;
-                lVol->SetUserLimits(new G4UserLimits(restG4Metadata->GetMaxStepSize(activeVolumeName) * mm));
+                logicalVolume->SetUserLimits(new G4UserLimits(restG4Metadata->GetMaxStepSize(activeVolumeName) * mm));
             }
         } else {
             cerr << "DetectorConstruction::Construct - Volume '" << activeVolumeName
@@ -220,15 +231,15 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
     return worldVolume;
 }
 
-G4VPhysicalVolume* DetectorConstruction::GetPhysicalVolume(const G4String& physicalVolumeName) const {
-    G4PhysicalVolumeStore* physicalVolumeStore = G4PhysicalVolumeStore::GetInstance();
-    TRestGeant4Metadata* restG4Metadata = fSimulationManager->GetRestMetadata();
-    const auto& geometryInfo = restG4Metadata->GetGeant4GeometryInfo();
-    vector<G4VPhysicalVolume*>::const_iterator physicalVolume;
+G4VPhysicalVolume *DetectorConstruction::GetPhysicalVolume(const G4String &physicalVolumeName) const {
+    G4PhysicalVolumeStore *physicalVolumeStore = G4PhysicalVolumeStore::GetInstance();
+    TRestGeant4Metadata *restG4Metadata = fSimulationManager->GetRestMetadata();
+    const auto &geometryInfo = restG4Metadata->GetGeant4GeometryInfo();
+    vector<G4VPhysicalVolume *>::const_iterator physicalVolume;
     for (physicalVolume = physicalVolumeStore->begin(); physicalVolume != physicalVolumeStore->end();
          physicalVolume++) {
         auto name = (*physicalVolume)->GetName();
-        auto alternativeName = (G4String)geometryInfo.GetAlternativeNameFromGeant4PhysicalName(name);
+        auto alternativeName = (G4String) geometryInfo.GetAlternativeNameFromGeant4PhysicalName(name);
         if (name == physicalVolumeName || alternativeName == physicalVolumeName) {
             return *physicalVolume;
         }
@@ -238,20 +249,20 @@ G4VPhysicalVolume* DetectorConstruction::GetPhysicalVolume(const G4String& physi
 }
 
 void DetectorConstruction::ConstructSDandField() {
-    const TRestGeant4Metadata& metadata = *fSimulationManager->GetRestMetadata();
+    const TRestGeant4Metadata &metadata = *fSimulationManager->GetRestMetadata();
 
-    set<G4LogicalVolume*> logicalVolumesSelected;
-    for (const auto& userSensitiveVolume : metadata.GetSensitiveVolumes()) {
+    set<G4LogicalVolume *> logicalVolumesSelected;
+    for (const auto &userSensitiveVolume: metadata.GetSensitiveVolumes()) {
         // Each sensitive detector declaration in the RML should correspond to at least one logical volume
-        G4LogicalVolume* logicalVolume;
+        G4LogicalVolume *logicalVolume;
         // Check if user selected a Geant4 physical volume by name
-        G4VPhysicalVolume* physicalVolume =
-            G4PhysicalVolumeStore::GetInstance()->GetVolume(userSensitiveVolume.Data(), false);
+        G4VPhysicalVolume *physicalVolume =
+                G4PhysicalVolumeStore::GetInstance()->GetVolume(userSensitiveVolume.Data(), false);
         if (physicalVolume == nullptr) {
             const G4String geant4VolumeName =
-                metadata.GetGeant4GeometryInfo()
-                    .GetGeant4PhysicalNameFromAlternativeName(userSensitiveVolume.Data())
-                    .Data();
+                    metadata.GetGeant4GeometryInfo()
+                            .GetGeant4PhysicalNameFromAlternativeName(userSensitiveVolume.Data())
+                            .Data();
             // Check if user selected a Geant4 physical volume by REST name (only relevant for assemblies)
             physicalVolume = G4PhysicalVolumeStore::GetInstance()->GetVolume(geant4VolumeName, false);
         }
@@ -268,25 +279,25 @@ void DetectorConstruction::ConstructSDandField() {
             // Check if the user string matches a logical volume by expanding the input as a regex
             // This can have multiple hits
             const auto logicalVolumesMatchingExpression =
-                metadata.GetGeant4GeometryInfo().GetAllLogicalVolumesMatchingExpression(userSensitiveVolume);
+                    metadata.GetGeant4GeometryInfo().GetAllLogicalVolumesMatchingExpression(userSensitiveVolume);
             if (logicalVolumesMatchingExpression.empty()) {
                 cerr << "Detector construction error: could not find matching logical volume(s) for '"
                      << userSensitiveVolume << "'" << endl;
                 exit(1);
             } else {
-                for (const auto& logicalVolumeName : logicalVolumesMatchingExpression) {
+                for (const auto &logicalVolumeName: logicalVolumesMatchingExpression) {
                     logicalVolumesSelected.insert(
-                        G4LogicalVolumeStore::GetInstance()->GetVolume(logicalVolumeName.Data(), false));
+                            G4LogicalVolumeStore::GetInstance()->GetVolume(logicalVolumeName.Data(), false));
                 }
             }
         }
     }
 
-    G4SDManager* SDManager = G4SDManager::GetSDMpointer();
+    G4SDManager *SDManager = G4SDManager::GetSDMpointer();
 
-    for (G4LogicalVolume* logicalVolume : logicalVolumesSelected) {
+    for (G4LogicalVolume *logicalVolume: logicalVolumesSelected) {
         auto name = logicalVolume->GetName();
-        G4VSensitiveDetector* sensitiveDetector = new SensitiveDetector(fSimulationManager, name);
+        G4VSensitiveDetector *sensitiveDetector = new SensitiveDetector(fSimulationManager, name);
         SDManager->AddNewDetector(sensitiveDetector);
         logicalVolume->SetSensitiveDetector(sensitiveDetector);
 
@@ -295,26 +306,26 @@ void DetectorConstruction::ConstructSDandField() {
     }
 }
 
-void TRestGeant4GeometryInfo::PopulateFromGeant4World(const G4VPhysicalVolume* world) {
-    auto detector = (DetectorConstruction*)G4RunManager::GetRunManager()->GetUserDetectorConstruction();
-    TRestGeant4Metadata* restG4Metadata = detector->fSimulationManager->GetRestMetadata();
+void TRestGeant4GeometryInfo::PopulateFromGeant4World(const G4VPhysicalVolume *world) {
+    auto detector = (DetectorConstruction *) G4RunManager::GetRunManager()->GetUserDetectorConstruction();
+    TRestGeant4Metadata *restG4Metadata = detector->fSimulationManager->GetRestMetadata();
 
     const size_t n = int(world->GetLogicalVolume()->GetNoDaughters());
     for (size_t i = 0; i < n + 1; i++) {  // world is the + 1
-        G4VPhysicalVolume* volume;
+        G4VPhysicalVolume *volume;
         if (i == n) {
-            volume = const_cast<G4VPhysicalVolume*>(world);
+            volume = const_cast<G4VPhysicalVolume *>(world);
         } else {
             volume = world->GetLogicalVolume()->GetDaughter(i);
         }
-        TString namePhysical = (TString)volume->GetName();
+        TString namePhysical = (TString) volume->GetName();
         if (fGdmlNewPhysicalNames.size() > i) {
             // it has been filled
             fGeant4PhysicalNameToNewPhysicalNameMap[namePhysical] = fGdmlNewPhysicalNames[i];
         }
         TString physicalNewName = GetAlternativeNameFromGeant4PhysicalName(namePhysical);
-        TString nameLogical = (TString)volume->GetLogicalVolume()->GetName();
-        TString nameMaterial = (TString)volume->GetLogicalVolume()->GetMaterial()->GetName();
+        TString nameLogical = (TString) volume->GetLogicalVolume()->GetName();
+        TString nameMaterial = (TString) volume->GetLogicalVolume()->GetMaterial()->GetName();
         auto position = volume->GetTranslation();
 
         fPhysicalToLogicalVolumeMap[physicalNewName] = nameLogical;


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 24](https://badgen.net/badge/PR%20Size/Ok%3A%2024/green) [![](https://gitlab.cern.ch/rest-for-physics/restG4/badges/lobis-from-gdml/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/restG4/-/commits/lobis-from-gdml) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=lobis-from-gdml)](https://github.com/rest-for-physics/restG4/commits/lobis-from-gdml)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Using the `gdml` generator will now use a logical volume (if only one physical volume matches) instead of throwing error.