### PR TITLE
New example to generate decay spectra as a tree

### DIFF
--- a/examples/15.DecaySpectra/GenerateTrees.C
+++ b/examples/15.DecaySpectra/GenerateTrees.C
@@ -1,0 +1,64 @@
+
+using namespace std;
+
+void GenerateTrees(const char *filename) {
+    gSystem->Load("libRestFramework.so");
+    gSystem->Load("libRestGeant4.so");
+
+    TRestRun run(filename);
+    cout << "Number of entries: " << run.GetEntries() << endl;
+
+    TRestGeant4Event *event = run.GetInputEvent<TRestGeant4Event>();
+    run.GetEntry(0);
+
+    const TString primaryName = event->GetPrimaryEventParticleName();
+    // Create a new tree to store gammas from the primary particle
+    TFile *f = new TFile(TString::Format("ParticlesFrom%sDecay.root", primaryName.Data()), "RECREATE");
+
+    const vector <string> particlesToRecord = {"gamma", "e-", "e+", "alpha"};
+    // create a new tree for each particle
+    map < string, TTree * > trees;
+    for (const auto &particle: particlesToRecord) {
+        // we cannot use the particle name (e.g. gamma) as a tree name, because it is a reserved word
+        trees[particle] = new TTree(TString::Format("decay_%s", particle.c_str()),
+                                    TString::Format("%s particles", particle.c_str()));
+    }
+
+    // create a branch for each particle
+    map<string, double> energies;
+    for (const auto &particle: particlesToRecord) {
+        energies[particle] = 0;
+        trees[particle]->Branch("energy", &energies[particle], "energy/D");
+    }
+
+    const string detectorName = "detector";
+    for (int n = 0; n < run.GetEntries(); n++) {
+        // print the progress every 1%
+        if (n % (run.GetEntries() / 100) == 0) {
+            cout << "Progress: " << n * 100 / run.GetEntries() << "%" << endl;
+        }
+        run.GetEntry(n);
+        // iterate over all particles in the event
+        for (const auto &track: event->GetTracks()) {
+            // if particle not in the list of particles to record, skip it
+            const string particleName = track.GetParticleName().Data();
+            if (find(particlesToRecord.begin(), particlesToRecord.end(), particleName) ==
+                particlesToRecord.end()) {
+                continue;
+            }
+            // record energy at the point of exit from the "detector" sphere (if it exits)
+            const auto &hits = track.GetHits();
+            for (int i = 0; i < hits.GetNumberOfHits(); i++) {
+                if (hits.GetVolumeName(i) == detectorName && hits.GetProcessName(i) == "Transportation") {
+                    // this is more accurate than track.GetInitialKineticEnergy()
+                    // because it takes into account energy loss in the detector
+                    energies[particleName] = hits.GetKineticEnergy(i);
+                    trees[particleName]->Fill();
+                }
+            }
+        }
+    }
+
+    f->Write();
+    f->Close();
+}

--- a/examples/15.DecaySpectra/geometry/setup.gdml
+++ b/examples/15.DecaySpectra/geometry/setup.gdml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+
+<!DOCTYPE gdml [
+        <!ENTITY materials SYSTEM "https://rest-for-physics.github.io/materials/materials.xml">
+        ]>
+
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+    <define>
+        <constant name="worldSize" value="100"/>
+    </define>
+
+    &materials;
+
+    <solids>
+        <box name="worldSolid" x="worldSize" y="worldSize" z="worldSize" lunit="mm"/>
+        <orb name="detectorSphereSolid" r="50" lunit="mm"/>
+    </solids>
+
+    <structure>
+
+        <volume name="detectorVolume">
+            <materialref ref="Vacuum"/>
+            <solidref ref="detectorSphereSolid"/>
+        </volume>
+
+        <volume name="World">
+            <materialref ref="Vacuum"/>
+            <solidref ref="worldSolid"/>
+
+            <physvol name="detector">
+                <volumeref ref="detectorVolume"/>
+                <position name="detectorPosition" unit="mm" x="0" y="0" z="0"/>
+            </physvol>
+        </volume>
+
+    </structure>
+
+    <setup name="Default" version="1.0">
+        <world ref="World"/>
+    </setup>
+
+</gdml>

--- a/examples/15.DecaySpectra/simulation.rml
+++ b/examples/15.DecaySpectra/simulation.rml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<restG4>
+
+    <globals>
+        <parameter name="mainDataPath" value=""/>
+        <parameter name="verboseLevel" value="essential"/>
+        <variable name="REST_ISOTOPE" value="U238"/>
+    </globals>
+
+    <TRestRun name="Metadata">
+        <parameter name="experimentName" value="DecaySpectra"/>
+        <parameter name="runType" value="simulation"/>
+        <parameter name="runNumber" value="1"/>
+        <parameter name="runTag" value="${REST_ISOTOPE}"/>
+        <parameter name="outputFileName" value="Run[fRunNumber]_[fRunTag]_[fExperimentName].root"/>
+        <parameter name="runDescription" value=""/>
+        <parameter name="user" value="${USER}"/>
+        <parameter name="overwrite" value="off"/>
+        <parameter name="readOnly" value="false"/>
+    </TRestRun>
+
+    <TRestGeant4Metadata name="DecaySpectra" title="DecaySpectra_{REST_ISOTOPE}">
+
+        <parameter name="gdmlFile" value="geometry/setup.gdml"/>
+        <parameter name="subEventTimeDelay" value="100" units="us"/>
+
+        <parameter name="seed" value="1000"/>
+
+        <!-- The number of events to be simulated is now defined in TRestGeant4Metadata -->
+        <parameter name="nEvents" value="10000000"/>
+        <parameter name="saveAllEvents" value="true"/>
+
+        <generator type="point" position="(0,0,0)" units="mm">
+            <source particle="${REST_ISOTOPE}" fullChain="on">
+                <angular type="isotropic"/>
+                <energy type="mono" energy="0keV"/>
+            </source>
+        </generator>
+
+        <detector>
+            <parameter name="energyRange" value="(0,1)" units="GeV"/>
+            <volume name="detector" sensitive="true" maxStepSize="1mm"/>
+        </detector>
+
+    </TRestGeant4Metadata>
+
+    <TRestGeant4PhysicsLists name="default" title="First physics list implementation.">
+
+        <parameter name="ionLimitStepList" value="F20,Ne20"/>
+
+        <parameter name="cutForGamma" value="0.01" units="mm"/>
+        <parameter name="cutForElectron" value="2" units="mm"/>
+        <parameter name="cutForPositron" value="1" units="mm"/>
+
+        <parameter name="cutForMuon" value="1" units="mm"/>
+        <parameter name="cutForNeutron" value="1" units="mm"/>
+        <parameter name="minEnergyRangeProductionCuts" value="1" units="keV"/>
+        <parameter name="maxEnergyRangeProductionCuts" value="1" units="GeV"/>
+
+        <!-- EM Physics lists -->
+        <physicsList name="G4EmStandardPhysics_option4"> <!-- "G4EmPenelopePhysics", "G4EmStandardPhysics_option3" -->
+            <option name="pixe" value="true"/>
+        </physicsList>
+
+        <!-- Decay physics lists -->
+        <physicsList name="G4DecayPhysics"></physicsList>
+        <physicsList name="G4RadioactiveDecayPhysics"></physicsList>
+        <physicsList name="G4RadioactiveDecay">
+            <option name="ICM" value="true"/>
+            <option name="ARM" value="true"/>
+        </physicsList>
+
+        <!-- Hadron physics lists -->
+        <physicsList name="G4HadronElasticPhysicsHP"></physicsList>
+        <physicsList name="G4IonBinaryCascadePhysics"></physicsList>
+        <physicsList name="G4HadronPhysicsQGSP_BIC_HP"></physicsList>
+        <physicsList name="G4NeutronTrackingCut"></physicsList>
+        <physicsList name="G4EmExtraPhysics"></physicsList>
+
+    </TRestGeant4PhysicsLists>
+
+</restG4>


### PR DESCRIPTION
I have added a new example which illustrates how to use restG4 to generate the decay spectra of a given decay.

It stores an energy distribution as a separate TTree for gamma, e-, e+ and alpha particles produced by the decay. This tree is generated by a macro present in the example. A root histogram could also be produced which could be used as the primary energy distribution in a simulation.

- [ ] Create histograms with energy distribution for particles
- [ ] Add README.md for example
- [ ] Add basic validation to the example (check statistical properties of spectra)

