### PR TITLE
Integrating restG4 validation inside framework

### DIFF
--- a/.github/workflows/frameworkValidation.yml
+++ b/.github/workflows/frameworkValidation.yml
@@ -1,0 +1,24 @@
+name: Framework Validation
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  release:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  CMAKE_BUILD_TYPE: Release
+  REST_PATH: /rest/restG4/install
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  framework-validation:
+    uses: rest-for-physics/framework/.github/workflows/validation.yml@validation_framework

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CMAKE_BUILD_TYPE: Release
-  REST_PATH: /rest/restG4/install
+  REST_INSTALL_PATH: /rest/restG4/install
   RESTG4_PATH: restG4
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
@@ -43,13 +43,13 @@ jobs:
       - name: Build and install
         uses: rest-for-physics/framework/.github/actions/build@master
         with:
-          cmake-flags: "-DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DREST_G4=ON -DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }}"
+          cmake-flags: "-DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DREST_G4=ON -DCMAKE_INSTALL_PREFIX=${{ env.REST_INSTALL_PATH }}"
           branch: ${{ env.BRANCH_NAME }}
       - name: Cache framework installation
         id: framework-install-restG4-cache
         uses: actions/cache@v3
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
 
   check-installation:
@@ -63,27 +63,27 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Check libraries
         run: |
           echo $LD_LIBRARY_PATH
-          ls -lht ${{ env.REST_PATH }}
-          ls -lht ${{ env.REST_PATH }}/lib | grep .so
-          ls -lht ${{ env.REST_PATH }}/bin
+          ls -lht ${{ env.REST_INSTALL_PATH }}
+          ls -lht ${{ env.REST_INSTALL_PATH }}/lib | grep .so
+          ls -lht ${{ env.REST_INSTALL_PATH }}/bin
       - name: Check root
         run: |
           root-config --version
           root -b -q
       - name: Check framework
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cat ${{ env.REST_PATH }}/thisREST.sh
-          cat ${{ env.REST_PATH }}/bin/rest-config
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cat ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cat ${{ env.REST_INSTALL_PATH }}/bin/rest-config
           rest-config --welcome
       - name: Check restG4
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
           restG4 --help
 
   restG4-standalone-install:
@@ -103,11 +103,11 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Build as standalone
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
           cd ${{ env.RESTG4_PATH }}
           mkdir -p build-standalone && cd build-standalone
           cmake ../ -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_INSTALL_PREFIX=/rest/restG4-standalone/install
@@ -126,12 +126,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/01.NLDBD/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/01.NLDBD/
           restG4 NLDBD.rml -o Run00001_NLDBD_Test.root
           restRoot -b -q Validate.C'("Run00001_NLDBD_Test.root")'
 
@@ -147,12 +147,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/03.Fluorescence/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/03.Fluorescence/
           restG4 gamma.rml -o gamma_fluorescence.root
           restManager --c g4Analysis.rml --f gamma_fluorescence.root -o gamma_fluorescence_analysis.root
           restRoot -b -q Validate.C'("gamma_fluorescence_analysis.root")'
@@ -169,12 +169,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/04.MuonScan/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/04.MuonScan/
           restG4 MuonsFromPoint.rml -o MuonsFromPoint.root
           restRoot -b -q ValidateMuonsFromPoint.C'("MuonsFromPoint.root")'
           restG4 CosmicMuonsFromWall.rml -o CosmicMuonsFromWall.root
@@ -196,12 +196,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/05.PandaXIII/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/05.PandaXIII/
           restG4 Xe136bb0n.rml -o Xe136bb0n.root
           restRoot -b -q Validate.C'("Xe136bb0n.root")'
 
@@ -217,12 +217,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/06.IonRecoils/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/06.IonRecoils/
           restG4 recoils.rml -o Run00001_F20_Recoils.root
           restRoot -b -q Validate.C'("Run00001_F20_Recoils.root")'
 
@@ -238,12 +238,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/07.FullChainDecay/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/07.FullChainDecay/
           restG4 fullChain.rml -o Run00001_U238_FullChainDecay.root
           restRoot -b -q Validate.C'("Run00001_U238_FullChainDecay.root", 15)'
           restG4 singleDecay.rml -o Run00002_U238_SingleChainDecay.root
@@ -264,12 +264,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/08.Alphas/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/08.Alphas/
           mkdir data
           export REST_ENERGY=5
           export REST_FOIL=1
@@ -298,12 +298,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/09.Pb210_Shield/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/09.Pb210_Shield/
           restG4 Pb210.rml -o Run00001_Pb210_Shielding.root
           restRoot -b -q Validate.C'("Run00001_Pb210_Shielding.root")'
 
@@ -319,12 +319,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/10.Geometries/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/10.Geometries/
           restG4 Assembly.rml -o Run00001_Assembly_Assembly.root
           restRoot -b -q Validate.C'("Run00001_Assembly_Assembly.root")'
 
@@ -340,19 +340,19 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Launching Gammas
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/11.Xrays/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/11.Xrays/
           restG4 xrays.rml -o xrays_simulation.root
           restManager --c analysis.rml --f xrays_simulation.root --o xrays_simulation_analysis.root
           restRoot -b -q GetQE.C'("xrays_simulation_analysis.root")'
       - name: Launching Fe55 source
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/11.Xrays/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/11.Xrays/
           restG4 Fe55.rml -o Fe55_simulation.root
           restManager --c analysis.rml --f Fe55_simulation.root --o Fe55_simulation_analysis.root
           restRoot -b -q ValidateFe55.C'("Fe55_simulation_analysis.root")'
@@ -369,12 +369,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/12.Generators/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/12.Generators/
           restG4 CosineSquaredCircle.rml -o CosineSquaredCircle.root
           restRoot -b -q ValidateCosineSquared.C'("CosineSquaredCircle.root")'
           restG4 CosmicGenerator.rml -o CosmicGenerator.root
@@ -392,12 +392,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/13.IAXO/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/13.IAXO/
           restG4 Neutrons.rml -o Neutrons.root
           restRoot -b -q Validate.C'("Neutrons.root")'
 
@@ -413,12 +413,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/14.DetectorResponse/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/14.DetectorResponse/
           source launchResponse.sh
           restManager --c analysis.rml --f RestG4_XenonNeon_30Pct_1.5bar_Drift3cm_Size6cm.root
           restRoot -b -q ValidateResponse.C'("G4Analysis_XenonNeon_30Pct_1.5bar_Drift3cm_Size6cm.root")'
@@ -436,17 +436,17 @@ jobs:
       - name: Build and install
         uses: rest-for-physics/framework/.github/actions/build@master
         with:
-          cmake-flags: "-DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DREST_G4=ON -DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }}"
+          cmake-flags: "-DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DREST_G4=ON -DCMAKE_INSTALL_PREFIX=${{ env.REST_INSTALL_PATH }}"
           branch: ${{ env.BRANCH_NAME }}
       - name: Use old materials for reference Geant4 version
         run: |
-          cd ${{ env.REST_PATH }}
+          cd ${{ env.REST_INSTALL_PATH }}
           find . -name "*.gdml" | xargs sed -i 's/https:\/\/rest-for-physics.github.io\/materials\/rest.xml/https:\/\/rest-for-physics.github.io\/materials\/legacy\/v1.4\/rest.xml/g'
       - name: Cache framework installation
         id: framework-install-restG4-cache-reference
         uses: actions/cache@v3
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
 
   check-installation-reference:
@@ -460,7 +460,7 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache-reference
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Check root
         run: |
@@ -468,13 +468,13 @@ jobs:
           root -b -q
       - name: Check framework
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cat ${{ env.REST_PATH }}/thisREST.sh
-          cat ${{ env.REST_PATH }}/bin/rest-config
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cat ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cat ${{ env.REST_INSTALL_PATH }}/bin/rest-config
           rest-config --welcome
       - name: Check restG4
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
           restG4 --help
 
   restG4-examples-01-reference:
@@ -489,12 +489,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache-reference
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/01.NLDBD/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/01.NLDBD/
           restG4 NLDBD.rml -o Run00001_NLDBD_Test.root
           restRoot -b -q Validate.C'("Run00001_NLDBD_Test.root")'
 
@@ -510,12 +510,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache-reference
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/06.IonRecoils/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/06.IonRecoils/
           restG4 recoils.rml -o Run00001_F20_Recoils.root
           restRoot -b -q Validate.C'("Run00001_F20_Recoils.root")'
 
@@ -531,12 +531,12 @@ jobs:
         uses: actions/cache@v3
         id: framework-install-restG4-cache-reference
         with:
-          path: ${{ env.REST_PATH }}
+          path: ${{ env.REST_INSTALL_PATH }}
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
       - name: Run example
         run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_PATH }}/examples/restG4/07.FullChainDecay/
+          source ${{ env.REST_INSTALL_PATH }}/thisREST.sh
+          cd ${{ env.REST_INSTALL_PATH }}/examples/restG4/07.FullChainDecay/
           restG4 fullChain.rml -o Run00001_U238_FullChainDecay.root
           restRoot -b -q Validate.C'("Run00001_U238_FullChainDecay.root", 15)'
           restG4 singleDecay.rml -o Run00002_U238_SingleChainDecay.root

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,16 +2,13 @@ name: Validation
 
 on:
   workflow_dispatch:
+  workflow_call:
 
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
   release:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 env:
   CMAKE_BUILD_TYPE: Release
@@ -25,35 +22,22 @@ defaults:
 
 jobs:
 
-  framework-test:
-    name: Build and run tests
+  precommit-config:
+    name: Validate pre-commit config
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
-      - name: Checkout framework
+      - name: Checkout restG4
+        uses: rest-for-physics/framework/.github/actions/checkout@master
+        with:
+          branch: ${{ env.BRANCH_NAME }}
+          repository: rest-for-physics/restG4
+          path: ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
+      - name: Verify pre-commit config files match
         run: |
-          git clone https://github.com/rest-for-physics/framework.git ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
           cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          ./scripts/checkoutRemoteBranch.sh ${{ env.BRANCH_NAME }}
-          git log -1 --stat
-      - uses: actions/checkout@v3
-      - name: Setup, build and install
-        run: |
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          git submodule init source/libraries/geant4 && git submodule update source/libraries/geant4
-          cd source/libraries/geant4/ && ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/scripts/checkoutRemoteBranch.sh ${{ env.BRANCH_NAME }}
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          rm -rf source/packages/restG4/ && cp -r $GITHUB_WORKSPACE source/packages/restG4
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          mkdir -p ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/build && cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/build
-          cmake ../ -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DTEST=ON -DREST_WELCOME=ON -DREST_G4=ON -DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }}
-          make -j4 install
-      - name: Run tests
-        run: |
-          source ${{ env.REST_PATH }}/thisREST.sh
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/build
-          ctest --output-on-failure
+          curl https://raw.githubusercontent.com/rest-for-physics/framework/master/scripts/validatePreCommitConfig.py | python
 
   framework-install:
     name: Install framework with restG4
@@ -63,28 +47,11 @@ jobs:
     steps:
       - name: Print version of dependencies for image
         run: version.sh
-      - name: Checkout framework
-        run: |
-          git clone https://github.com/rest-for-physics/framework.git ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          ./scripts/checkoutRemoteBranch.sh ${{ env.BRANCH_NAME }}
-          git log -1 --stat
-      - uses: actions/checkout@v3
-      - name: Verify pre-commit config files match
-        run: |
-          cd $GITHUB_WORKSPACE
-          python ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/scripts/validatePreCommitConfig.py
-      - name: Setup, build and install
-        run: |
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          git submodule init source/libraries/geant4 && git submodule update source/libraries/geant4
-          cd source/libraries/geant4/ && ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/scripts/checkoutRemoteBranch.sh ${{ env.BRANCH_NAME }}
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          rm -rf source/packages/restG4/ && cp -r $GITHUB_WORKSPACE source/packages/restG4
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          mkdir -p ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/build && cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/build
-          cmake ../ -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DREST_G4=ON -DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }}
-          make -j4 install
+      - name: Build and install
+        uses: rest-for-physics/framework/.github/actions/build@master
+        with:
+          cmake-flags: "-DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DREST_G4=ON -DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }}"
+          branch: ${{ env.BRANCH_NAME }}
       - name: Cache framework installation
         id: framework-install-restG4-cache
         uses: actions/cache@v3
@@ -467,24 +434,11 @@ jobs:
     steps:
       - name: Print version of dependencies for image
         run: version.sh
-      - name: Checkout framework
-        run: |
-          git clone https://github.com/rest-for-physics/framework.git ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          ./scripts/checkoutRemoteBranch.sh ${{ env.BRANCH_NAME }}
-          git log -1 --stat
-      - uses: actions/checkout@v3
-      - name: Setup, build and install
-        run: |
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          git submodule init source/libraries/geant4 && git submodule update source/libraries/geant4
-          cd source/libraries/geant4/ && ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/scripts/checkoutRemoteBranch.sh ${{ env.BRANCH_NAME }}
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          rm -rf source/packages/restG4/ && cp -r $GITHUB_WORKSPACE source/packages/restG4
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
-          mkdir -p ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/build && cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}/build
-          cmake ../ -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DREST_G4=ON -DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }}
-          make -j4 install
+      - name: Build and install
+        uses: rest-for-physics/framework/.github/actions/build@master
+        with:
+          cmake-flags: "-DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DREST_WELCOME=ON -DREST_G4=ON -DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }}"
+          branch: ${{ env.BRANCH_NAME }}
       - name: Use old materials for reference Geant4 version
         run: |
           cd ${{ env.REST_PATH }}
@@ -497,7 +451,7 @@ jobs:
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
 
   check-installation-reference:
-    name: Check framework and restG4 are accessible
+    name: Check ref framework and restG4 are accessible
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-reference-jun2022
@@ -524,7 +478,6 @@ jobs:
           source ${{ env.REST_PATH }}/thisREST.sh
           restG4 --help
 
-
   restG4-examples-01-reference:
     name: "Reference Example 01: NLDBD"
     runs-on: ubuntu-latest
@@ -545,7 +498,6 @@ jobs:
           cd ${{ env.REST_PATH }}/examples/restG4/01.NLDBD/
           restG4 NLDBD.rml -o Run00001_NLDBD_Test.root
           restRoot -b -q Validate.C'("Run00001_NLDBD_Test.root")'
-
 
   restG4-examples-06-reference:
     name: "Reference Example 06: Ion recoils"

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -13,7 +13,7 @@ on:
 env:
   CMAKE_BUILD_TYPE: Release
   REST_PATH: /rest/framework/install
-  REST_FRAMEWORK_SOURCE_DIR: /rest/framework/source
+  RESTG4_PATH: restG4
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 defaults:
@@ -33,10 +33,10 @@ jobs:
         with:
           branch: ${{ env.BRANCH_NAME }}
           repository: rest-for-physics/restG4
-          path: ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
+          path: ${{ env.RESTG4_PATH }}
       - name: Verify pre-commit config files match
         run: |
-          cd ${{ env.REST_FRAMEWORK_SOURCE_DIR }}
+          cd ${{ env.RESTG4_PATH }}
           curl https://raw.githubusercontent.com/rest-for-physics/framework/master/scripts/validatePreCommitConfig.py | python
 
   framework-install:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -4,12 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
 
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-  release:
-
 env:
   CMAKE_BUILD_TYPE: Release
   REST_PATH: /rest/framework/install

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CMAKE_BUILD_TYPE: Release
-  REST_PATH: /rest/framework/install
+  REST_PATH: /rest/restG4/install
   RESTG4_PATH: restG4
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,7 +15,6 @@ defaults:
     shell: bash
 
 jobs:
-
   precommit-config:
     name: Validate pre-commit config
     runs-on: ubuntu-latest
@@ -94,7 +93,12 @@ jobs:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install, check-installation ]
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout restG4
+        uses: rest-for-physics/framework/.github/actions/checkout@master
+        with:
+          branch: ${{ env.BRANCH_NAME }}
+          repository: rest-for-physics/restG4
+          path: ${{ env.RESTG4_PATH }}
       - name: Restore cache
         uses: actions/cache@v3
         id: framework-install-restG4-cache
@@ -104,6 +108,7 @@ jobs:
       - name: Build as standalone
         run: |
           source ${{ env.REST_PATH }}/thisREST.sh
+          cd ${{ env.RESTG4_PATH }}
           mkdir -p build-standalone && cd build-standalone
           cmake ../ -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_INSTALL_PREFIX=/rest/restG4-standalone/install
           make -j4 install


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Medium: 124](https://badgen.net/badge/PR%20Size/Medium%3A%20124/orange) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=validation_framework)](https://github.com/rest-for-physics/restG4/commits/validation_framework)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Integrating `restG4` validation inside `framework:`
- Removal of unnecessary `ctest` since are done at `framework`
- Removal of concurrency since it is also performed at `framework`
- Avoid trigger of the validation on `validation.yml` since now it is done at `frameworkValidation.yml` although `validation.yml` can be triggered on `workflow_call` (manually).
- New validation file `frameworkValidation.yml` to trigger `framework` validation

I think we should clean up some validation jobs since they seems duplicated in `framework`

Related PR https://github.com/rest-for-physics/framework/pull/403