### PR TITLE
examples/08.alphas/Validate.C Fixing validation pipeline

### DIFF
--- a/examples/08.Alphas/Validate.C
+++ b/examples/08.Alphas/Validate.C
@@ -47,26 +47,28 @@ Int_t Validate() {
         return 30;
     }
 
-    if (TMath::Abs(thetaSample - thetaSampleRef) / thetaSampleRef >= 0.01) {
+    std::cout << "Theta sample : " << thetaSample << " Theta sample (ref): " << thetaSampleRef << std::endl;
+    if (TMath::Abs(thetaSample - thetaSampleRef) / TMath::Abs(thetaSampleRef) >= 0.01) {
         cout << "Wrong theta angle value for entry 100!" << endl;
         cout << "Theta value is : " << thetaSample << " while it should be : " << thetaSampleRef << endl;
         return 60;
     }
 
-    if (TMath::Abs(phiSample - phiSampleRef) / phiSampleRef >= 0.01) {
+    std::cout << "Phi sample : " << phiSample << " Phi sample (ref): " << phiSampleRef << std::endl;
+    if (TMath::Abs(phiSample - phiSampleRef) / TMath::Abs(phiSampleRef) >= 0.01) {
         cout << "Wrong phi angle value for entry 100!" << endl;
         cout << "Phi value is : " << phiSample << " while it should be : " << phiSampleRef << endl;
         return 60;
     }
 
-    if (TMath::Abs(thetaAverage - thetaAverageRef) / thetaAverageRef >= 0.01) {
+    if (TMath::Abs(thetaAverage - thetaAverageRef) / TMath::Abs(thetaAverageRef) >= 0.01) {
         cout << "Wrong theta angle average!" << endl;
         cout << "Theta angle average : " << thetaAverage << " while it should be : " << thetaAverageRef
              << endl;
         return 80;
     }
 
-    if (TMath::Abs(phiAverage - phiAverageRef) / phiAverageRef >= 0.01) {
+    if (TMath::Abs(phiAverage - phiAverageRef) / TMath::Abs(phiAverageRef) >= 0.01) {
         cout << "Wrong phi angle average!" << endl;
         cout << "Phi angle average : " << phiAverage << " while it should be : " << phiAverageRef << endl;
         return 90;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 6](https://badgen.net/badge/PR%20Size/Ok%3A%206/green) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=jgalan_restG4_pipeline)](https://github.com/rest-for-physics/restG4/commits/jgalan_restG4_pipeline)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->


The example alphas seems to give a different phi angle average.

The reference validation value for the average phi was: 0.07 which I imagine is compatible with angles between -Pi and Pi.

The average value that we are obtaining now is : 1.58265 which I believe it is compatible with angles between 0 and Pi.

Do we have some clues why this is now this way? @lobis?

EDIT: Inside `TRestGeant4Analysis` this angle is obtained from `TVector3::Phi` which states the angle is between -Pi and Pi.

https://root.cern.ch/doc/master/classTVector3.html#a32f9ef94d3f824f191d08edb9e968256

Thus, a perfectly isotropic distribution should lead to a value near 0.


