### PR TITLE
Pointing to proper branch in framework

### DIFF
--- a/.github/workflows/frameworkValidation.yml
+++ b/.github/workflows/frameworkValidation.yml
@@ -21,4 +21,4 @@ defaults:
 
 jobs:
   framework-validation:
-    uses: rest-for-physics/framework/.github/workflows/validation.yml@validation_framework
+    uses: rest-for-physics/framework/.github/workflows/validation.yml@master


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://github.com/rest-for-physics/restG4/actions/workflows/validation.yml/badge.svg?branch=g4_validation_master)](https://github.com/rest-for-physics/restG4/commits/g4_validation_master)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now restG4 framework validation is pointing to master branch

Related PR https://github.com/rest-for-physics/framework/pull/414