### PR TITLE
Using configurable time delay from G4Metadata subEventTimeDelay

### DIFF
--- a/src/DataModel.cxx
+++ b/src/DataModel.cxx
@@ -149,7 +149,7 @@ void TRestGeant4Track::UpdateTrack(const G4Track* track) {
 
     SetTimeOffset(globalTimeOffset);
 
-    const double precision = metadata->GetResetTimePrecision();
+    const double precision = metadata->GetResetTimePrecision() / CLHEP::microsecond;
     const double globalTime = track->GetGlobalTime() / CLHEP::microsecond;
 
     const auto processName = track->GetStep()->GetPostStepPoint()->GetProcessDefinedStep()->GetProcessName();

--- a/src/StackingAction.cxx
+++ b/src/StackingAction.cxx
@@ -13,7 +13,7 @@
 using namespace std;
 
 StackingAction::StackingAction(SimulationManager* simulationManager) : fSimulationManager(simulationManager) {
-    fMaxAllowedLifetime = fSimulationManager->GetRestMetadata()->GetSubEventTimeDelay();
+    fMaxAllowedLifetime = fSimulationManager->GetRestMetadata()->GetSubEventTimeDelay() * CLHEP::us;
 
     fMaxAllowedLifetimeWithUnit = G4BestUnit(fMaxAllowedLifetime, "Time");
 

--- a/src/StackingAction.cxx
+++ b/src/StackingAction.cxx
@@ -13,7 +13,7 @@
 using namespace std;
 
 StackingAction::StackingAction(SimulationManager* simulationManager) : fSimulationManager(simulationManager) {
-    fMaxAllowedLifetime = fSimulationManager->GetRestMetadata()->GetSubEventTimeDelay() * CLHEP::us;
+    fMaxAllowedLifetime = fSimulationManager->GetRestMetadata()->GetSubEventTimeDelay() * CLHEP::microsecond;
 
     fMaxAllowedLifetimeWithUnit = G4BestUnit(fMaxAllowedLifetime, "Time");
 

--- a/src/StackingAction.cxx
+++ b/src/StackingAction.cxx
@@ -13,7 +13,7 @@
 using namespace std;
 
 StackingAction::StackingAction(SimulationManager* simulationManager) : fSimulationManager(simulationManager) {
-    fMaxAllowedLifetime = 100;  // TODO: update this
+    fMaxAllowedLifetime = fSimulationManager->GetRestMetadata()->GetSubEventTimeDelay();
 
     fMaxAllowedLifetimeWithUnit = G4BestUnit(fMaxAllowedLifetime, "Time");
 


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://github.com/rest-for-physics/restG4/actions/workflows/frameworkValidation.yml/badge.svg?branch=subEventDelay)](https://github.com/rest-for-physics/restG4/commits/subEventDelay) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Using configurable time delay from G4Metadata subEventTimeDelay