### PR TITLE
PrimaryGeneratorAction fix setting of excitedLevel to particle gun

### DIFF
--- a/src/PrimaryGeneratorAction.cxx
+++ b/src/PrimaryGeneratorAction.cxx
@@ -443,7 +443,7 @@ G4ParticleDefinition* PrimaryGeneratorAction::SetParticleDefinition(Int_t partic
 
     G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
     fParticle = particleTable->FindParticle(particleName);
-    if (!fParticle) {
+    if (!fParticle || excitedEnergy > 0 || charge != 0) {
         fParticle = particleTable->FindParticle(particleName);
 
         // There might be a better way to do this


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://github.com/rest-for-physics/restG4/actions/workflows/frameworkValidation.yml/badge.svg?branch=aezq_fixSetParticleDef)](https://github.com/rest-for-physics/restG4/commits/aezq_fixSetParticleDef) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Fix to be able to set the excited energy and charge of the source particle. For example, for Kr-83m.
