### PR TITLE
Fix GDML logical volume generators in assemblies

### DIFF
--- a/src/DetectorConstruction.cxx
+++ b/src/DetectorConstruction.cxx
@@ -157,7 +157,8 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
         }
         if (gdmlPhysicalVolume == nullptr) {
             // perhaps the user selected a logical volume instead
-            auto physicalVolumes = geometryInfo.GetAllPhysicalVolumesFromLogical(generatorGeometryName.Data());
+            auto physicalVolumes =
+                geometryInfo.GetAllPhysicalVolumesFromLogical(generatorGeometryName.Data());
             if (physicalVolumes.size() == 1) {
                 gdmlPhysicalVolume = GetPhysicalVolume(physicalVolumes[0].Data());
                 cout << "Generator volume '" << primaryGeneratorInfo.GetSpatialGeneratorFrom()
@@ -174,9 +175,11 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
             exit(1);
         }
 
-        TVector3 genTranslation = geometryInfo.GetPosition(generatorGeometryName.Data());  // in world coordinates
+        TVector3 genTranslation =
+            geometryInfo.GetPosition(generatorGeometryName.Data());  // in world coordinates
         fGeneratorTranslation = {genTranslation.x(), genTranslation.y(), genTranslation.z()};
-        TRotation genRotation = geometryInfo.GetRotation(generatorGeometryName.Data());  // in world coordinates
+        TRotation genRotation =
+            geometryInfo.GetRotation(generatorGeometryName.Data());  // in world coordinates
         double angle;
         TVector3 axis;
         genRotation.AngleAxis(angle, axis);

--- a/src/DetectorConstruction.cxx
+++ b/src/DetectorConstruction.cxx
@@ -149,18 +149,23 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
 
     if (spatialGeneratorTypeEnum == TRestGeant4PrimaryGeneratorTypes::SpatialGeneratorTypes::VOLUME &&
         primaryGeneratorInfo.GetSpatialGeneratorFrom() != "Not defined") {
-        G4VPhysicalVolume* gdmlPhysicalVolume =
-            GetPhysicalVolume(primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());
+        TString generatorGeometryName = primaryGeneratorInfo.GetSpatialGeneratorFrom();
+        G4VPhysicalVolume* gdmlPhysicalVolume = GetPhysicalVolume(generatorGeometryName.Data());
+        if (gdmlPhysicalVolume != nullptr && !geometryInfo.IsValidPhysicalVolume(generatorGeometryName)) {
+            generatorGeometryName =
+                geometryInfo.GetAlternativeNameFromGeant4PhysicalName(gdmlPhysicalVolume->GetName());
+        }
         if (gdmlPhysicalVolume == nullptr) {
             // perhaps the user selected a logical volume instead
-            auto physicalVolumes = geometryInfo.GetAllPhysicalVolumesFromLogical(
-                primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());
+            auto physicalVolumes = geometryInfo.GetAllPhysicalVolumesFromLogical(generatorGeometryName.Data());
             if (physicalVolumes.size() == 1) {
                 gdmlPhysicalVolume = GetPhysicalVolume(physicalVolumes[0].Data());
                 cout << "Generator volume '" << primaryGeneratorInfo.GetSpatialGeneratorFrom()
                      << "' was not found in the geometry. Using the physical volume '" << physicalVolumes[0]
                      << "' instead, which was obtained from logical volume '"
                      << primaryGeneratorInfo.GetSpatialGeneratorFrom() << "'" << endl;
+                generatorGeometryName =
+                    geometryInfo.GetAlternativeNameFromGeant4PhysicalName(physicalVolumes[0]);
             }
         }
         if (gdmlPhysicalVolume == nullptr) {
@@ -169,11 +174,9 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
             exit(1);
         }
 
-        TVector3 genTranslation = geometryInfo.GetPosition(
-            primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());  // in world coordinates
+        TVector3 genTranslation = geometryInfo.GetPosition(generatorGeometryName.Data());  // in world coordinates
         fGeneratorTranslation = {genTranslation.x(), genTranslation.y(), genTranslation.z()};
-        TRotation genRotation = geometryInfo.GetRotation(
-            primaryGeneratorInfo.GetSpatialGeneratorFrom().Data());  // in world coordinates
+        TRotation genRotation = geometryInfo.GetRotation(generatorGeometryName.Data());  // in world coordinates
         double angle;
         TVector3 axis;
         genRotation.AngleAxis(angle, axis);


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 11](https://badgen.net/badge/PR%20Size/Ok%3A%2011/green) [![](https://github.com/rest-for-physics/restG4/actions/workflows/frameworkValidation.yml/badge.svg?branch=fix/logical-volume-generator-position)](https://github.com/rest-for-physics/restG4/commits/fix/logical-volume-generator-position) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

@rest-for-physics/restG4

## Summary
- Keep a separate geometry-info name for GDML volume generators after resolving the requested generator volume.
- When a generator is configured with a logical volume that maps to a unique physical volume, translate the resolved Geant4 physical name to the REST alternative physical-volume name before reading world position/rotation.
- Also handle direct Geant4 physical-volume names by translating them before querying `TRestGeant4GeometryInfo`.

## Motivation
A volume generator configured from a logical volume inside a GDML assembly can resolve to the correct Geant4 physical volume for sampling, but `TRestGeant4GeometryInfo::GetPosition` and `GetRotation` are keyed by REST alternative physical names. This caused a `std::out_of_range` exception when using an IAXO shielding-layer generator from `shieldingVolumeLayer1`.

## Validation
- Rebuilt `restG4` on `naf-iaxo` against the current REST install with Geant4 11.0.3.
- Ran a 20 s Pb210 full-chain smoke test using `IAXO-D1/ShieldingLayers.gdml` and `<generator type="volume" shape="gdml" from="shieldingVolumeLayer1">`.
- Result: exit code 0, 19,632 simulated decays, 0 stored events, no geometry lookup abort.

Note: local macOS build directory did not expose a `restG4` target, so the compile validation was done on the naf REST/Geant4 production build. 