### PR TITLE
Add ParticleHP physics-list options

### DIFF
--- a/include/PhysicsList.h
+++ b/include/PhysicsList.h
@@ -19,6 +19,7 @@ class PhysicsList : public G4VModularPhysicsList {
    protected:
     // Construct particle and physics
     virtual void InitializePhysicsLists();
+    void ApplyParticleHPOptions() const;
 
     void ConstructParticle() override;
     void ConstructProcess() override;

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -38,6 +38,7 @@
 #include <G4UImanager.hh>
 #include <G4UnitsTable.hh>
 #include <G4UniversalFluctuation.hh>
+#include <G4Version.hh>
 
 #include "Particles.h"
 
@@ -208,8 +209,15 @@ void PhysicsList::ApplyParticleHPOptions() const {
                                  &G4ParticleHPManager::SetProduceFissionFragments);
     ApplyParticleHPBooleanOption(fRestPhysicsLists, "useNRESP71Model", "UseNRESP71Model",
                                  &G4ParticleHPManager::SetUseNRESP71Model);
+#if G4VERSION_NUMBER >= 1100
     ApplyParticleHPBooleanOption(fRestPhysicsLists, "useWendtFissionModel", "UseWendtFissionModel",
                                  &G4ParticleHPManager::SetUseWendtFissionModel);
+#else
+    if (GetParticleHPOptionValue(fRestPhysicsLists, "useWendtFissionModel") != "NotDefined") {
+        G4cout << "Ignoring ParticleHP option 'UseWendtFissionModel': "
+               << "not available in this Geant4 version" << G4endl;
+    }
+#endif
 
     const TString verbose = GetParticleHPOptionValue(fRestPhysicsLists, "verbose");
     if (verbose != "NotDefined") {

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -21,6 +21,7 @@
 #include <G4IonTable.hh>
 #include <G4LossTableManager.hh>
 #include <G4NeutronTrackingCut.hh>
+#include <G4ParticleHPManager.hh>
 #include <G4ParticleTable.hh>
 #include <G4ParticleTypes.hh>
 #include <G4PhotonEvaporation.hh>
@@ -41,6 +42,36 @@
 #include "Particles.h"
 
 using namespace std;
+
+namespace {
+TString GetParticleHPOptionValue(const TRestGeant4PhysicsLists* physicsLists, const TString& option,
+                                 const TString& defaultValue = "NotDefined") {
+    const vector<TString> hpPhysicsLists = {"G4HadronPhysicsQGSP_BIC_HP", "G4HadronElasticPhysicsHP"};
+    for (const auto& physicsListName : hpPhysicsLists) {
+        const TString value = physicsLists->GetPhysicsListOptionValue(physicsListName, option, "NotDefined");
+        if (value != "NotDefined") {
+            return value;
+        }
+    }
+    return defaultValue;
+}
+
+using ParticleHPBoolSetter = void (G4ParticleHPManager::*)(G4bool);
+
+void ApplyParticleHPBooleanOption(const TRestGeant4PhysicsLists* physicsLists, const TString& option,
+                                  const string& geant4Option, ParticleHPBoolSetter setter) {
+    const TString value = GetParticleHPOptionValue(physicsLists, option);
+    if (value == "NotDefined") {
+        return;
+    }
+
+    const G4bool boolValue = StringToBool(value.Data());
+    G4cout << "Setting ParticleHP option '" << geant4Option << "' to '"
+           << (boolValue ? "true" : "false") << "'" << G4endl;
+    auto* manager = G4ParticleHPManager::GetInstance();
+    (manager->*setter)(boolValue);
+}
+}  // namespace
 
 PhysicsList::PhysicsList(SimulationManager* simulationManager, TRestGeant4PhysicsLists* physicsLists)
     : G4VModularPhysicsList(), fSimulationManager(simulationManager) {
@@ -162,6 +193,35 @@ void PhysicsList::InitializePhysicsLists() {
     G4cout << "Number of hadronic physics lists added " << fHadronPhys.size() << G4endl;
 }
 
+void PhysicsList::ApplyParticleHPOptions() const {
+    // ParticleHP options are global Geant4 settings. They must be applied before the hadronic
+    // constructors build the neutron processes.
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "usePhotoEvaporation",
+                                 "UseOnlyPhotoEvaporation",
+                                 &G4ParticleHPManager::SetUseOnlyPhotoEvaporation);
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "skipMissingIsotopes",
+                                 "SkipMissingIsotopes", &G4ParticleHPManager::SetSkipMissingIsotopes);
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "neglectDopplerBroadening",
+                                 "NeglectDoppler", &G4ParticleHPManager::SetNeglectDoppler);
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "doNotAdjustFinalState",
+                                 "DoNotAdjustFinalState",
+                                 &G4ParticleHPManager::SetDoNotAdjustFinalState);
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "produceFissionFragments",
+                                 "ProduceFissionFragments",
+                                 &G4ParticleHPManager::SetProduceFissionFragments);
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "useNRESP71Model",
+                                 "UseNRESP71Model", &G4ParticleHPManager::SetUseNRESP71Model);
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "useWendtFissionModel",
+                                 "UseWendtFissionModel",
+                                 &G4ParticleHPManager::SetUseWendtFissionModel);
+
+    const TString verbose = GetParticleHPOptionValue(fRestPhysicsLists, "verbose");
+    if (verbose != "NotDefined") {
+        G4cout << "Setting ParticleHP option 'VerboseLevel' to '" << verbose << "'" << G4endl;
+        G4ParticleHPManager::GetInstance()->SetVerboseLevel(verbose.Atoi());
+    }
+}
+
 void PhysicsList::ConstructParticle() {
     // pseudo-particles
     G4Geantino::GeantinoDefinition();
@@ -228,6 +288,8 @@ void PhysicsList::ConstructProcess() {
     if (fRadDecPhysicsList) {
         fRadDecPhysicsList->ConstructProcess();
     }
+
+    ApplyParticleHPOptions();
 
     // Hadronic physics lists
     for (auto& hadronicPhysicsList : fHadronPhys) {

--- a/src/PhysicsList.cxx
+++ b/src/PhysicsList.cxx
@@ -66,8 +66,8 @@ void ApplyParticleHPBooleanOption(const TRestGeant4PhysicsLists* physicsLists, c
     }
 
     const G4bool boolValue = StringToBool(value.Data());
-    G4cout << "Setting ParticleHP option '" << geant4Option << "' to '"
-           << (boolValue ? "true" : "false") << "'" << G4endl;
+    G4cout << "Setting ParticleHP option '" << geant4Option << "' to '" << (boolValue ? "true" : "false")
+           << "'" << G4endl;
     auto* manager = G4ParticleHPManager::GetInstance();
     (manager->*setter)(boolValue);
 }
@@ -196,23 +196,19 @@ void PhysicsList::InitializePhysicsLists() {
 void PhysicsList::ApplyParticleHPOptions() const {
     // ParticleHP options are global Geant4 settings. They must be applied before the hadronic
     // constructors build the neutron processes.
-    ApplyParticleHPBooleanOption(fRestPhysicsLists, "usePhotoEvaporation",
-                                 "UseOnlyPhotoEvaporation",
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "usePhotoEvaporation", "UseOnlyPhotoEvaporation",
                                  &G4ParticleHPManager::SetUseOnlyPhotoEvaporation);
-    ApplyParticleHPBooleanOption(fRestPhysicsLists, "skipMissingIsotopes",
-                                 "SkipMissingIsotopes", &G4ParticleHPManager::SetSkipMissingIsotopes);
-    ApplyParticleHPBooleanOption(fRestPhysicsLists, "neglectDopplerBroadening",
-                                 "NeglectDoppler", &G4ParticleHPManager::SetNeglectDoppler);
-    ApplyParticleHPBooleanOption(fRestPhysicsLists, "doNotAdjustFinalState",
-                                 "DoNotAdjustFinalState",
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "skipMissingIsotopes", "SkipMissingIsotopes",
+                                 &G4ParticleHPManager::SetSkipMissingIsotopes);
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "neglectDopplerBroadening", "NeglectDoppler",
+                                 &G4ParticleHPManager::SetNeglectDoppler);
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "doNotAdjustFinalState", "DoNotAdjustFinalState",
                                  &G4ParticleHPManager::SetDoNotAdjustFinalState);
-    ApplyParticleHPBooleanOption(fRestPhysicsLists, "produceFissionFragments",
-                                 "ProduceFissionFragments",
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "produceFissionFragments", "ProduceFissionFragments",
                                  &G4ParticleHPManager::SetProduceFissionFragments);
-    ApplyParticleHPBooleanOption(fRestPhysicsLists, "useNRESP71Model",
-                                 "UseNRESP71Model", &G4ParticleHPManager::SetUseNRESP71Model);
-    ApplyParticleHPBooleanOption(fRestPhysicsLists, "useWendtFissionModel",
-                                 "UseWendtFissionModel",
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "useNRESP71Model", "UseNRESP71Model",
+                                 &G4ParticleHPManager::SetUseNRESP71Model);
+    ApplyParticleHPBooleanOption(fRestPhysicsLists, "useWendtFissionModel", "UseWendtFissionModel",
                                  &G4ParticleHPManager::SetUseWendtFissionModel);
 
     const TString verbose = GetParticleHPOptionValue(fRestPhysicsLists, "verbose");


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 67](https://badgen.net/badge/PR%20Size/Ok%3A%2067/green) [![](https://github.com/rest-for-physics/restG4/actions/workflows/frameworkValidation.yml/badge.svg?branch=codex/particlehp-options)](https://github.com/rest-for-physics/restG4/commits/codex/particlehp-options) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Summary

- add REST physics-list options for Geant4 ParticleHP settings
- map options from `G4HadronPhysicsQGSP_BIC_HP` or `G4HadronElasticPhysicsHP` entries onto `G4ParticleHPManager`
- apply the options before hadronic physics constructors build neutron processes

## Why

Neutron-capture gamma validation needs a way to compare the default ParticleHP capture final states with the PhotonEvaporation de-excitation model and strict isotope-data handling from RML configuration, without relying on fragile runtime UI-command plumbing.

## Options Added

- `usePhotoEvaporation` -> `SetUseOnlyPhotoEvaporation`
- `skipMissingIsotopes` -> `SetSkipMissingIsotopes`
- `neglectDopplerBroadening` -> `SetNeglectDoppler`
- `doNotAdjustFinalState` -> `SetDoNotAdjustFinalState`
- `produceFissionFragments` -> `SetProduceFissionFragments`
- `useNRESP71Model` -> `SetUseNRESP71Model`
- `useWendtFissionModel` -> `SetUseWendtFissionModel`
- `verbose` -> `SetVerboseLevel`

## Validation

- `git diff --check`
- deployed and built on the NAF REST/Geant4 stack, including `RestGeant4`, `RestRestG4`, and `restG4`
- direct NAF initialization check with a PhotonEvaporation validation RML reached physics-list construction and logged:
  - `Setting ParticleHP option 'UseOnlyPhotoEvaporation' to 'true'`
  - `Setting ParticleHP option 'SkipMissingIsotopes' to 'true'`
- local macOS CMake checkout does not currently expose a `RestRestG4` target, so local validation was limited to diff checks for these package files 