### PR TITLE
Update cosmic validation references after geant4lib normalization fix

### DIFF
--- a/examples/12.Generators/ValidateCosmicGenerator.C
+++ b/examples/12.Generators/ValidateCosmicGenerator.C
@@ -124,14 +124,18 @@ Int_t ValidateCosmicGenerator(const char* filename) {
         return 12;
     }
 
-    const auto cosmicFluxRef = 0.108215;
+    // Reference values updated after rest-for-physics/geant4lib#151 removed a double-counted
+    // 2*pi azimuth factor from the Guan formula. The integrated flux dropped by exactly 2*pi
+    // (0.108215 -> 0.0172229 counts/cm2/s, i.e. ~1.03 muons/cm2/min, matching the textbook
+    // sea-level value) and the equivalent simulated time N/(flux*surface) grew accordingly.
+    const auto cosmicFluxRef = 0.0172229;
     if (TMath::Abs(metadata->GetCosmicFluxInCountsPerCm2PerSecond() - cosmicFluxRef) / cosmicFluxRef >
         tolerance) {
         cout << "wrong cosmic flux: " << metadata->GetCosmicFluxInCountsPerCm2PerSecond() << endl;
         return 13;
     }
 
-    const auto simulationTimeRef = 9804.87;
+    const auto simulationTimeRef = 61606.0;
     if (TMath::Abs(metadata->GetEquivalentSimulatedTime() - simulationTimeRef) / simulationTimeRef >
         tolerance) {
         cout << "wrong equivalent simulation time: " << metadata->GetEquivalentSimulatedTime() << endl;


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 6](https://badgen.net/badge/PR%20Size/Ok%3A%206/green) [![](https://github.com/rest-for-physics/restG4/actions/workflows/frameworkValidation.yml/badge.svg?branch=cris_update_cosmic_validation_references)](https://github.com/rest-for-physics/restG4/commits/cris_update_cosmic_validation_references) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

rest-for-physics/geant4lib#151 (merged 2026-05-18) removed a double-counted 2pi azimuth factor from the analytic Guan cosmic muon formula. The integrated flux reported by
TRestGeant4Metadata::GetCosmicFluxInCountsPerCm2PerSecond dropped by exactly 2pi, from 0.108215 to 0.0172229 counts/cm2/s — the new value matches the textbook sea-level muon flux of ~1/cm2/min, supporting the correctness of the fix. The equivalent simulated time N/(flux x surface) = 1e6/(0.0172229 x 942.4778) grows accordingly to ~61606 s.

The validation references were not updated at the time, so "Example 12: Generators" has been failing in all CI pipelines across the rest-for-physics repositories since the merge (exit code 13, "wrong cosmic flux"). 