### PR TITLE
Accept C++17 or newer Geant4 (not exactly C++17)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,14 @@ find_package(Geant4 REQUIRED ui_all vis_all)
 include(${Geant4_USE_FILE})
 message("-- Found Geant4 version: ${Geant4_VERSION}")
 
-# Check Geant4 C++ standard is correct
-execute_process(COMMAND geant4-config --cxxstd OUTPUT_VARIABLE GEANT4_CXX_STD)
-if (NOT ${GEANT4_CXX_STD} MATCHES "17")
+# Check Geant4 C++ standard is recent enough. REST requires C++17 or newer, so
+# accept 17 and any later standard (e.g. C++20 shipped by recent LCG/CVMFS Geant4).
+execute_process(COMMAND geant4-config --cxxstd OUTPUT_VARIABLE GEANT4_CXX_STD
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (GEANT4_CXX_STD LESS 17)
     message(
         FATAL_ERROR
-            "Geant4 installation was compiled with C++${GEANT4_CXX_STD} standard, but C++17 is required for REST"
+            "Geant4 installation was compiled with the C++${GEANT4_CXX_STD} standard, but REST requires C++17 or newer"
     )
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,12 @@ include(${Geant4_USE_FILE})
 message("-- Found Geant4 version: ${Geant4_VERSION}")
 
 # Check Geant4 C++ standard is recent enough. REST requires C++17 or newer, so
-# accept 17 and any later standard (e.g. C++20 shipped by recent LCG/CVMFS Geant4).
-execute_process(COMMAND geant4-config --cxxstd OUTPUT_VARIABLE GEANT4_CXX_STD
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
+# accept 17 and any later standard (e.g. C++20 shipped by recent LCG/CVMFS
+# Geant4).
+execute_process(
+    COMMAND geant4-config --cxxstd
+    OUTPUT_VARIABLE GEANT4_CXX_STD
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
 if (GEANT4_CXX_STD LESS 17)
     message(
         FATAL_ERROR


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 6](https://badgen.net/badge/PR%20Size/Ok%3A%206/green) [![](https://github.com/rest-for-physics/restG4/actions/workflows/frameworkValidation.yml/badge.svg?branch=cris_accept_cxx17_or_newer)](https://github.com/rest-for-physics/restG4/commits/cris_accept_cxx17_or_newer) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Problem

The CMake configuration aborts unless `geant4-config --cxxstd` is exactly `"17"`:

```cmake
if (NOT ${GEANT4_CXX_STD} MATCHES "17")
    message(FATAL_ERROR "... C++17 is required for REST")
endif ()
```

Recent Geant4 builds are compiled with C++20, so configuration fails even though REST builds and runs fine against them:

Geant4 installation was compiled with C++20 standard, but C++17 is required for REST

## Fix

Compare numerically and require C++17 or newer, so 17/20/23 all pass while
genuinely older standards are still rejected:
```
execute_process(COMMAND geant4-config --cxxstd OUTPUT_VARIABLE GEANT4_CXX_STD
                OUTPUT_STRIP_TRAILING_WHITESPACE)
if (GEANT4_CXX_STD LESS 17)
    message(FATAL_ERROR "... REST requires C++17 or newer")
endif ()
``` 